### PR TITLE
Increase wire.MaxBlockPayload to 8MB

### DIFF
--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -23,8 +23,8 @@ const defaultTransactionAlloc = 2048
 const MaxBlocksPerMsg = 500
 
 // MaxBlockPayload is the maximum bytes a block message can be in bytes.
-// After Segregated Witness, the max block payload has been raised to 4MB.
-const MaxBlockPayload = 4000000
+// After Segregated Witness, the max block payload has been raised to 8MB.
+const MaxBlockPayload = 8000000
 
 // maxTxPerBlock is the maximum number of transactions that could
 // possibly fit into a block.

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -36,7 +36,7 @@ func TestBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(4000000)
+	wantPayload := uint32(8000000)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgmerkleblock_test.go
+++ b/wire/msgmerkleblock_test.go
@@ -38,7 +38,7 @@ func TestMerkleBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(4000000)
+	wantPayload := uint32(8000000)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -35,7 +35,7 @@ func TestTx(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	wantPayload := uint32(1000 * 4000)
+	wantPayload := uint32(1000 * 8000)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
This variable seems redundant to the blockchain.MaxBlockBaseSize to make the `wire` and `blockchain` self-contained.
We've updated the `blockchain.MaxBlockBaseSize` to 8MB for LBRY, but missed this one?