### PR TITLE
Enable txindex=1 for Docker Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ COPY --from=build-container /go/bin /bin
 
 VOLUME ["/root/.lbcd"]
 
+RUN   echo "txindex=1" >> /root/.lbcd/lbcd.conf
+
 EXPOSE 9245 9246
 
 ENTRYPOINT ["lbcd"]


### PR DESCRIPTION
Curently running lbcd inside docker do not enable txindex support with is required for most apps/services.
This PR adds txindex=1 to config file during build process to enable it by default.