### PR TITLE
Mem pressure try 3

### DIFF
--- a/blockchain/claimtrie.go
+++ b/blockchain/claimtrie.go
@@ -35,7 +35,7 @@ func (b *BlockChain) ParseClaimScripts(block *btcutil.Block, bn *blockNode, view
 	ht := block.Height()
 
 	for _, tx := range block.Transactions() {
-		h := handler{ht, tx, view, map[string][]byte{}}
+		h := handler{ht, tx, view, map[change.ClaimID][]byte{}}
 		if err := h.handleTxIns(b.claimTrie); err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ type handler struct {
 	ht    int32
 	tx    *btcutil.Tx
 	view  *UtxoViewpoint
-	spent map[string][]byte
+	spent map[change.ClaimID][]byte
 }
 
 func (h *handler) handleTxIns(ct *claimtrie.ClaimTrie) error {

--- a/claimtrie/change/change.go
+++ b/claimtrie/change/change.go
@@ -78,9 +78,10 @@ func (c *Change) Marshal(enc *bytes.Buffer) error {
 		binary.BigEndian.PutUint32(temp[:4], uint32(len(c.SpentChildren)))
 		enc.Write(temp[:4])
 		for key := range c.SpentChildren {
-			binary.BigEndian.PutUint16(temp[:2], uint16(len(key))) // technically limited to 255; not sure we trust it
+			keySize := uint16(len(key))
+			binary.BigEndian.PutUint16(temp[:2], keySize) // technically limited to 255; not sure we trust it
 			enc.Write(temp[:2])
-			enc.WriteString(key)
+			enc.WriteString(key[:keySize])
 		}
 	} else {
 		binary.BigEndian.PutUint32(temp[:4], 0)

--- a/claimtrie/change/claimid.go
+++ b/claimtrie/change/claimid.go
@@ -39,8 +39,8 @@ func NewIDFromString(s string) (id ClaimID, err error) {
 }
 
 // Key is for in-memory maps
-func (id ClaimID) Key() string {
-	return string(id[:])
+func (id ClaimID) Key() ClaimID {
+	return id
 }
 
 // String is for anything written to a DB

--- a/claimtrie/cmd/cmd/node.go
+++ b/claimtrie/cmd/cmd/node.go
@@ -52,10 +52,11 @@ func NewNodeDumpCommand() *cobra.Command {
 			}
 			defer repo.Close()
 
-			changes, err := repo.LoadChanges([]byte(name))
+			changes, closer, err := repo.LoadChanges([]byte(name))
 			if err != nil {
 				return errors.Wrapf(err, "load commands")
 			}
+			defer closer()
 
 			for _, chg := range changes {
 				if chg.Height > height {

--- a/claimtrie/node/manager.go
+++ b/claimtrie/node/manager.go
@@ -53,10 +53,11 @@ func (nm *BaseManager) NodeAt(height int32, name []byte) (*Node, error) {
 
 	n, changes, oldHeight := nm.cache.fetch(name, height)
 	if n == nil {
-		changes, err := nm.repo.LoadChanges(name)
+		changes, closer, err := nm.repo.LoadChanges(name)
 		if err != nil {
 			return nil, errors.Wrap(err, "in load changes")
 		}
+		defer closer()
 
 		if nm.tempChanges != nil { // making an assumption that we only ever have tempChanges for a single block
 			changes = append(changes, nm.tempChanges[string(name)]...)

--- a/claimtrie/node/node.go
+++ b/claimtrie/node/node.go
@@ -14,12 +14,12 @@ type Node struct {
 	TakenOverAt int32     // The height at when the current BestClaim took over.
 	Claims      ClaimList // List of all Claims.
 	Supports    ClaimList // List of all Supports, including orphaned ones.
-	SupportSums map[string]int64
+	SupportSums map[change.ClaimID]int64
 }
 
 // New returns a new node.
 func New() *Node {
-	return &Node{SupportSums: map[string]int64{}}
+	return &Node{SupportSums: map[change.ClaimID]int64{}}
 }
 
 func (n *Node) HasActiveBestClaim() bool {
@@ -166,7 +166,7 @@ func (n *Node) handleExpiredAndActivated(height int32) int {
 	}
 
 	changes := 0
-	update := func(items ClaimList, sums map[string]int64) ClaimList {
+	update := func(items ClaimList, sums map[change.ClaimID]int64) ClaimList {
 		for i := 0; i < len(items); i++ {
 			c := items[i]
 			if c.Status == Accepted && c.ActiveAt <= height && c.VisibleAt <= height {
@@ -343,7 +343,7 @@ func (n *Node) SortClaimsByBid() {
 func (n *Node) Clone() *Node {
 	clone := New()
 	if n.SupportSums != nil {
-		clone.SupportSums = map[string]int64{}
+		clone.SupportSums = map[change.ClaimID]int64{}
 		for key, value := range n.SupportSums {
 			clone.SupportSums[key] = value
 		}

--- a/claimtrie/node/noderepo/noderepo_test.go
+++ b/claimtrie/node/noderepo/noderepo_test.go
@@ -92,8 +92,9 @@ func testNodeRepo(t *testing.T, repo node.Repo, setup, cleanup func()) {
 		err := repo.AppendChanges(tt.changes)
 		r.NoError(err)
 
-		changes, err := repo.LoadChanges(testNodeName1)
+		changes, closer, err := repo.LoadChanges(testNodeName1)
 		r.NoError(err)
+		defer closer()
 		r.Equalf(tt.expected, changes[:len(tt.expected)], tt.name)
 
 		cleanup()
@@ -150,8 +151,9 @@ func testNodeRepo(t *testing.T, repo node.Repo, setup, cleanup func()) {
 			r.NoError(err)
 		}
 
-		changes, err := repo.LoadChanges(testNodeName1)
+		changes, closer, err := repo.LoadChanges(testNodeName1)
 		r.NoError(err)
+		defer closer()
 		r.Equalf(tt.expected, changes[:len(tt.expected)], tt.name)
 
 		cleanup()

--- a/claimtrie/node/noderepo/pebble.go
+++ b/claimtrie/node/noderepo/pebble.go
@@ -30,13 +30,17 @@ func (a *pooledMerger) Swap(i, j int) {
 }
 
 func (a *pooledMerger) MergeNewer(value []byte) error {
-	a.values = append(a.values, value)
+	vc := a.pool.Get().([]byte)[:0]
+	vc = append(vc, value...)
+	a.values = append(a.values, vc)
 	a.index = append(a.index, len(a.values))
 	return nil
 }
 
 func (a *pooledMerger) MergeOlder(value []byte) error {
-	a.values = append(a.values, value)
+	vc := a.pool.Get().([]byte)[:0]
+	vc = append(vc, value...)
+	a.values = append(a.values, vc)
 	a.index = append(a.index, -len(a.values))
 	return nil
 }
@@ -53,6 +57,9 @@ func (a *pooledMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 }
 
 func (a *pooledMerger) Close() error {
+	for i := range a.values {
+		a.pool.Put(a.values[i])
+	}
 	a.pool.Put(a.buffer)
 	return nil
 }

--- a/claimtrie/node/repo.go
+++ b/claimtrie/node/repo.go
@@ -13,7 +13,9 @@ type Repo interface {
 
 	// LoadChanges loads changes of a node up to (includes) the specified height.
 	// If no changes found, both returned slice and error will be nil.
-	LoadChanges(name []byte) ([]change.Change, error)
+	// The returned closer func() should be called to release changes after
+	// work on them is finished.
+	LoadChanges(name []byte) (changes []change.Change, closer func(), err error)
 
 	DropChanges(name []byte, finalHeight int32) error
 

--- a/config.go
+++ b/config.go
@@ -117,6 +117,7 @@ type config struct {
 	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
 	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
 	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemProfile           string        `long:"memprofile" description:"Write memory profile to the specified file"`
 	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
 	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
 	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`

--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -516,6 +516,9 @@ func (c *dbCache) flush() error {
 		return err
 	}
 
+	cachedKeys.Recycle()
+	cachedRemove.Recycle()
+
 	return nil
 }
 
@@ -574,9 +577,16 @@ func (c *dbCache) commitTx(tx *transaction) error {
 			return err
 		}
 
+		pk := tx.pendingKeys
+		pr := tx.pendingRemove
+
 		// Clear the transaction entries since they have been committed.
 		tx.pendingKeys = nil
 		tx.pendingRemove = nil
+
+		pk.Recycle()
+		pr.Recycle()
+
 		return nil
 	}
 

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -319,7 +319,7 @@ func testWriteFailures(tc *testContext) bool {
 		file: &mockFile{forceSyncErr: true, maxSize: -1},
 	}
 	store.writeCursor.Unlock()
-	err := tc.db.(*db).cache.flush()
+	err := tc.db.(*db).cache.flush(nil)
 	if !checkDbError(tc.t, testName, err, database.ErrDriverSpecific) {
 		return false
 	}

--- a/database/internal/treap/common.go
+++ b/database/internal/treap/common.go
@@ -42,6 +42,13 @@ type treapNode struct {
 	right    *treapNode
 }
 
+func (n *treapNode) Reset() {
+	n.key = nil
+	n.value = nil
+	n.left = nil
+	n.right = nil
+}
+
 // nodeSize returns the number of bytes the specified node occupies including
 // the struct fields and the contents of the key and value.
 func nodeSize(node *treapNode) uint64 {

--- a/database/internal/treap/common_test.go
+++ b/database/internal/treap/common_test.go
@@ -49,7 +49,7 @@ testLoop:
 		for j := 0; j < test.numNodes; j++ {
 			var key [4]byte
 			binary.BigEndian.PutUint32(key[:], uint32(j))
-			node := newTreapNode(key[:], key[:], 0)
+			node := getTreapNode(key[:], key[:], 0, 0)
 			nodes = append(nodes, node)
 		}
 

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -7,17 +7,20 @@ package treap
 import (
 	"bytes"
 	"math/rand"
+	"sync"
 )
+
+var nodePool = &sync.Pool{New: func() interface{} { return newTreapNode(nil, nil, 0) }}
 
 // cloneTreapNode returns a shallow copy of the passed node.
 func cloneTreapNode(node *treapNode) *treapNode {
-	return &treapNode{
-		key:      node.key,
-		value:    node.value,
-		priority: node.priority,
-		left:     node.left,
-		right:    node.right,
-	}
+	clone := nodePool.Get().(*treapNode)
+	clone.key = node.key
+	clone.value = node.value
+	clone.priority = node.priority
+	clone.left = node.left
+	clone.right = node.right
+	return clone
 }
 
 // Immutable represents a treap data structure which is used to hold ordered
@@ -165,7 +168,10 @@ func (t *Immutable) Put(key, value []byte) *Immutable {
 	}
 
 	// Link the new node into the binary tree in the correct position.
-	node := newTreapNode(key, value, rand.Int())
+	node := nodePool.Get().(*treapNode)
+	node.key = key
+	node.value = value
+	node.priority = rand.Int()
 	parent := parents.At(0)
 	if compareResult < 0 {
 		parent.left = node
@@ -357,4 +363,24 @@ func (t *Immutable) ForEach(fn func(k, v []byte) bool) {
 // documentation for the Immutable structure for more details.
 func NewImmutable() *Immutable {
 	return &Immutable{}
+}
+
+func (t *Immutable) Recycle() {
+	var parents parentStack
+	for node := t.root; node != nil; node = node.left {
+		parents.Push(node)
+	}
+
+	for parents.Len() > 0 {
+		node := parents.Pop()
+
+		// Extend the nodes to traverse by all children to the left of
+		// the current node's right child.
+		for n := node.right; n != nil; n = n.left {
+			parents.Push(n)
+		}
+
+		node.Reset()
+		nodePool.Put(node)
+	}
 }

--- a/database/internal/treap/mutable.go
+++ b/database/internal/treap/mutable.go
@@ -145,7 +145,10 @@ func (t *Mutable) Put(key, value []byte) {
 	}
 
 	// Link the new node into the binary tree in the correct position.
-	node := newTreapNode(key, value, rand.Int())
+	node := nodePool.Get().(*treapNode)
+	node.key = key
+	node.value = value
+	node.priority = rand.Int()
 	t.count++
 	t.totalSize += nodeSize(node)
 	parent := parents.At(0)
@@ -275,4 +278,24 @@ func (t *Mutable) Reset() {
 // documentation for the Mutable structure for more details.
 func NewMutable() *Mutable {
 	return &Mutable{}
+}
+
+func (t *Mutable) Recycle() {
+	var parents parentStack
+	for node := t.root; node != nil; node = node.left {
+		parents.Push(node)
+	}
+
+	for parents.Len() > 0 {
+		node := parents.Pop()
+
+		// Extend the nodes to traverse by all children to the left of
+		// the current node's right child.
+		for n := node.right; n != nil; n = n.left {
+			parents.Push(n)
+		}
+
+		node.Reset()
+		nodePool.Put(node)
+	}
 }

--- a/database/internal/treap/treapiter.go
+++ b/database/internal/treap/treapiter.go
@@ -326,6 +326,7 @@ func (iter *Iterator) ForceReseek() {
 //   	}
 //   }
 func (t *Mutable) Iterator(startKey, limitKey []byte) *Iterator {
+	t.generation++
 	iter := &Iterator{
 		t:        t,
 		root:     t.root,

--- a/lbcd.go
+++ b/lbcd.go
@@ -92,6 +92,25 @@ func btcdMain(serverChan chan<- *server) error {
 		defer pprof.StopCPUProfile()
 	}
 
+	// Write memory profile if requested.
+	if cfg.MemProfile != "" {
+		f, err := os.Create(cfg.MemProfile + ".heap")
+		if err != nil {
+			btcdLog.Errorf("Unable to create mem profile: %v", err)
+			return err
+		}
+		defer f.Close()
+		defer pprof.Lookup("heap").WriteTo(f, 0)
+
+		f, err = os.Create(cfg.MemProfile + ".allocs")
+		if err != nil {
+			btcdLog.Errorf("Unable to create mem profile: %v", err)
+			return err
+		}
+		defer f.Close()
+		defer pprof.Lookup("allocs").WriteTo(f, 0)
+	}
+
 	// Perform upgrades to btcd as new versions require it.
 	if err := doUpgrades(); err != nil {
 		btcdLog.Errorf("%v", err)

--- a/lbcd.go
+++ b/lbcd.go
@@ -300,7 +300,9 @@ func main() {
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  This value was arrived at with the help of profiling live
 	// usage.
-	debug.SetGCPercent(10)
+	if _, ok := os.LookupEnv("GOGC"); !ok {
+		debug.SetGCPercent(10)
+	}
 
 	// Up some limits.
 	if err := limits.SetLimits(); err != nil {

--- a/sample-lbcd.conf
+++ b/sample-lbcd.conf
@@ -376,6 +376,9 @@
 ; Write CPU profile to the specified file.
 ; cpuprofile=
 
+; Write memory profile to the specified file.
+; memprofile=
+
 ; The port used to listen for HTTP profile requests.  The profile server will
 ; be disabled if this option is not specified.  The profile information can be
 ; accessed at http://localhost:<profileport>/debug/pprof once running.


### PR DESCRIPTION
Based on work by @BrannonKing in the mem_pressure_try_2 and reduce_memory_pressure branches...

I think the most impactful thing is reducing time for "Building the entire claim trie in RAM" phase. It's CPU intensive, so time spent in GC reduces performance.

Second thing is allowing the GOGC=<percent> environment variable to take effect overriding the hard-coded value (10%). Ten percent is quite low, and leads to constant GC activity. Opening up GOGC=<percent> allows tradeoffs to be made.

I don't think reducing GC burden accelerates the overall sync process. (I had hoped it might...) But other things (network/disk?) are limiting as long as there's _enough_ CPU available. I tried running "env GOGC=400 ./lbcd" and although CPU use is low, sync doesn't go faster. :-( Perhaps the way to accelerate sync would be syncing blocks from multiple peers.

Finally, I am not entirely comfortable with the Mutable/Immutable treap changes in database/... It's my best attempt to combine original Immutable treap semantics with the way that ffldb/transaction actually wants to use it. I was very successful in reducing allocations, but I'm still not sure it's safe. It could also be fragile if treap is used in different ways in the future.

Test data forthcoming...