### PR TITLE
Allow environment var GOGC=<percent> to override hard-coded SetGCPercent(10)

### DIFF
--- a/lbcd.go
+++ b/lbcd.go
@@ -281,7 +281,9 @@ func main() {
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  This value was arrived at with the help of profiling live
 	// usage.
-	debug.SetGCPercent(10)
+	if _, ok := os.LookupEnv("GOGC"); !ok {
+		debug.SetGCPercent(10)
+	}
 
 	// Up some limits.
 	if err := limits.SetLimits(); err != nil {


### PR DESCRIPTION
Unbundled from PR https://github.com/lbryio/lbcd/pull/43

See that for usage/testing. (TODO)

The default (10) only lets heap grow 10% before triggering GC. Running with (for example) "GOGC=100" will reduce CPU usage while heap is allowed to fluctuate more.
