### PR TITLE
Pebble pooled merger

### DIFF
--- a/claimtrie/change/change.go
+++ b/claimtrie/change/change.go
@@ -78,9 +78,10 @@ func (c *Change) Marshal(enc *bytes.Buffer) error {
 		binary.BigEndian.PutUint32(temp[:4], uint32(len(c.SpentChildren)))
 		enc.Write(temp[:4])
 		for key := range c.SpentChildren {
-			binary.BigEndian.PutUint16(temp[:2], uint16(len(key))) // technically limited to 255; not sure we trust it
+			keySize := uint16(len(key))
+			binary.BigEndian.PutUint16(temp[:2], keySize) // technically limited to 255; not sure we trust it
 			enc.Write(temp[:2])
-			enc.WriteString(key)
+			enc.WriteString(key[:keySize])
 		}
 	} else {
 		binary.BigEndian.PutUint32(temp[:4], 0)

--- a/claimtrie/node/noderepo/pebble.go
+++ b/claimtrie/node/noderepo/pebble.go
@@ -30,13 +30,17 @@ func (a *pooledMerger) Swap(i, j int) {
 }
 
 func (a *pooledMerger) MergeNewer(value []byte) error {
-	a.values = append(a.values, value)
+	vc := a.pool.Get().([]byte)[:0]
+	vc = append(vc, value...)
+	a.values = append(a.values, vc)
 	a.index = append(a.index, len(a.values))
 	return nil
 }
 
 func (a *pooledMerger) MergeOlder(value []byte) error {
-	a.values = append(a.values, value)
+	vc := a.pool.Get().([]byte)[:0]
+	vc = append(vc, value...)
+	a.values = append(a.values, vc)
 	a.index = append(a.index, -len(a.values))
 	return nil
 }
@@ -53,6 +57,9 @@ func (a *pooledMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 }
 
 func (a *pooledMerger) Close() error {
+	for i := range a.values {
+		a.pool.Put(a.values[i])
+	}
 	a.pool.Put(a.buffer)
 	return nil
 }


### PR DESCRIPTION
Unbundled from PR: https://github.com/lbryio/lbcd/pull/43

See that for usage/testing.

Based on work by @BrannonKing in mem_pressure_try_2 and reduce_memory_pressure.

The stuff in 92d8b5f20ee81c97aa9f6fab434251f573819f10 is something that seems unsafe which I found while debugging. The database was being corrupted, and I was seeing crashes in Change.Unmarshal() trying to read bytes that weren't there.

Eventually I figured out the problem was in the merger, and submitted 728ddc4dfa4533d5155a3c4c831d604e29d74537
