### PR TITLE
Add treapNode pool. Reduce cloneTreapNode() allocations.

### DIFF
--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -516,6 +516,9 @@ func (c *dbCache) flush() error {
 		return err
 	}
 
+	cachedKeys.Recycle()
+	cachedRemove.Recycle()
+
 	return nil
 }
 
@@ -574,9 +577,16 @@ func (c *dbCache) commitTx(tx *transaction) error {
 			return err
 		}
 
+		pk := tx.pendingKeys
+		pr := tx.pendingRemove
+
 		// Clear the transaction entries since they have been committed.
 		tx.pendingKeys = nil
 		tx.pendingRemove = nil
+
+		pk.Recycle()
+		pr.Recycle()
+
 		return nil
 	}
 

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -319,7 +319,7 @@ func testWriteFailures(tc *testContext) bool {
 		file: &mockFile{forceSyncErr: true, maxSize: -1},
 	}
 	store.writeCursor.Unlock()
-	err := tc.db.(*db).cache.flush()
+	err := tc.db.(*db).cache.flush(nil)
 	if !checkDbError(tc.t, testName, err, database.ErrDriverSpecific) {
 		return false
 	}

--- a/database/internal/treap/common.go
+++ b/database/internal/treap/common.go
@@ -42,6 +42,13 @@ type treapNode struct {
 	right    *treapNode
 }
 
+func (n *treapNode) Reset() {
+	n.key = nil
+	n.value = nil
+	n.left = nil
+	n.right = nil
+}
+
 // nodeSize returns the number of bytes the specified node occupies including
 // the struct fields and the contents of the key and value.
 func nodeSize(node *treapNode) uint64 {

--- a/database/internal/treap/common_test.go
+++ b/database/internal/treap/common_test.go
@@ -49,7 +49,7 @@ testLoop:
 		for j := 0; j < test.numNodes; j++ {
 			var key [4]byte
 			binary.BigEndian.PutUint32(key[:], uint32(j))
-			node := newTreapNode(key[:], key[:], 0)
+			node := getTreapNode(key[:], key[:], 0, 0)
 			nodes = append(nodes, node)
 		}
 

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -7,17 +7,20 @@ package treap
 import (
 	"bytes"
 	"math/rand"
+	"sync"
 )
+
+var nodePool = &sync.Pool{New: func() interface{} { return newTreapNode(nil, nil, 0) }}
 
 // cloneTreapNode returns a shallow copy of the passed node.
 func cloneTreapNode(node *treapNode) *treapNode {
-	return &treapNode{
-		key:      node.key,
-		value:    node.value,
-		priority: node.priority,
-		left:     node.left,
-		right:    node.right,
-	}
+	clone := nodePool.Get().(*treapNode)
+	clone.key = node.key
+	clone.value = node.value
+	clone.priority = node.priority
+	clone.left = node.left
+	clone.right = node.right
+	return clone
 }
 
 // Immutable represents a treap data structure which is used to hold ordered
@@ -165,7 +168,10 @@ func (t *Immutable) Put(key, value []byte) *Immutable {
 	}
 
 	// Link the new node into the binary tree in the correct position.
-	node := newTreapNode(key, value, rand.Int())
+	node := nodePool.Get().(*treapNode)
+	node.key = key
+	node.value = value
+	node.priority = rand.Int()
 	parent := parents.At(0)
 	if compareResult < 0 {
 		parent.left = node
@@ -357,4 +363,24 @@ func (t *Immutable) ForEach(fn func(k, v []byte) bool) {
 // documentation for the Immutable structure for more details.
 func NewImmutable() *Immutable {
 	return &Immutable{}
+}
+
+func (t *Immutable) Recycle() {
+	var parents parentStack
+	for node := t.root; node != nil; node = node.left {
+		parents.Push(node)
+	}
+
+	for parents.Len() > 0 {
+		node := parents.Pop()
+
+		// Extend the nodes to traverse by all children to the left of
+		// the current node's right child.
+		for n := node.right; n != nil; n = n.left {
+			parents.Push(n)
+		}
+
+		node.Reset()
+		nodePool.Put(node)
+	}
 }

--- a/database/internal/treap/mutable.go
+++ b/database/internal/treap/mutable.go
@@ -145,7 +145,10 @@ func (t *Mutable) Put(key, value []byte) {
 	}
 
 	// Link the new node into the binary tree in the correct position.
-	node := newTreapNode(key, value, rand.Int())
+	node := nodePool.Get().(*treapNode)
+	node.key = key
+	node.value = value
+	node.priority = rand.Int()
 	t.count++
 	t.totalSize += nodeSize(node)
 	parent := parents.At(0)
@@ -275,4 +278,24 @@ func (t *Mutable) Reset() {
 // documentation for the Mutable structure for more details.
 func NewMutable() *Mutable {
 	return &Mutable{}
+}
+
+func (t *Mutable) Recycle() {
+	var parents parentStack
+	for node := t.root; node != nil; node = node.left {
+		parents.Push(node)
+	}
+
+	for parents.Len() > 0 {
+		node := parents.Pop()
+
+		// Extend the nodes to traverse by all children to the left of
+		// the current node's right child.
+		for n := node.right; n != nil; n = n.left {
+			parents.Push(n)
+		}
+
+		node.Reset()
+		nodePool.Put(node)
+	}
 }

--- a/database/internal/treap/treapiter.go
+++ b/database/internal/treap/treapiter.go
@@ -326,6 +326,7 @@ func (iter *Iterator) ForceReseek() {
 //   	}
 //   }
 func (t *Mutable) Iterator(startKey, limitKey []byte) *Iterator {
+	t.generation++
 	iter := &Iterator{
 		t:        t,
 		root:     t.root,


### PR DESCRIPTION
Unbundled from PR https://github.com/lbryio/lbcd/pull/43

See that for usage/testing.

Based on work by @BrannonKing in mem_pressure_try_2 and reduce_memory_pressure.

I am not entirely comfortable with the changes. It's my best attempt to combine original Immutable treap semantics with the way that ffldb/transaction actually wants to use it. I was very successful in reducing temporary allocations, but I'm still not sure it's safe. It could also be fragile if treap is used in different ways in the future.
