### PR TITLE
Reduce claimtrie temp allocs.

### DIFF
--- a/blockchain/claimtrie.go
+++ b/blockchain/claimtrie.go
@@ -35,7 +35,7 @@ func (b *BlockChain) ParseClaimScripts(block *btcutil.Block, bn *blockNode, view
 	ht := block.Height()
 
 	for _, tx := range block.Transactions() {
-		h := handler{ht, tx, view, map[string][]byte{}}
+		h := handler{ht, tx, view, map[change.ClaimID][]byte{}}
 		if err := h.handleTxIns(b.claimTrie); err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ type handler struct {
 	ht    int32
 	tx    *btcutil.Tx
 	view  *UtxoViewpoint
-	spent map[string][]byte
+	spent map[change.ClaimID][]byte
 }
 
 func (h *handler) handleTxIns(ct *claimtrie.ClaimTrie) error {

--- a/blockchain/claimtrie.go
+++ b/blockchain/claimtrie.go
@@ -171,6 +171,9 @@ func (b *BlockChain) GetClaimsForName(height int32, name string) (string, *node.
 
 	n, err := b.claimTrie.NodeAt(height, normalizedName)
 	if err != nil {
+		if n != nil {
+			n.Close()
+		}
 		return string(normalizedName), nil, err
 	}
 

--- a/claimtrie/change/claimid.go
+++ b/claimtrie/change/claimid.go
@@ -39,8 +39,8 @@ func NewIDFromString(s string) (id ClaimID, err error) {
 }
 
 // Key is for in-memory maps
-func (id ClaimID) Key() string {
-	return string(id[:])
+func (id ClaimID) Key() ClaimID {
+	return id
 }
 
 // String is for anything written to a DB

--- a/claimtrie/claimtrie_test.go
+++ b/claimtrie/claimtrie_test.go
@@ -133,6 +133,7 @@ func TestNormalizationFork(t *testing.T) {
 	r.NoError(err)
 	r.NotNil(n.BestClaim)
 	r.Equal(int32(1), n.TakenOverAt)
+	n.Close()
 
 	o8 := wire.OutPoint{Hash: hash, Index: 8}
 	err = ct.AddClaim([]byte("aÑEJO"), o8, change.NewClaimID(o8), 8)
@@ -150,6 +151,7 @@ func TestNormalizationFork(t *testing.T) {
 	n, err = ct.nodeManager.NodeAt(ct.nodeManager.Height(), []byte("test"))
 	r.NoError(err)
 	r.Equal(int64(18), n.BestClaim.Amount+n.SupportSums[n.BestClaim.ClaimID.Key()])
+	n.Close()
 }
 
 func TestActivationsOnNormalizationFork(t *testing.T) {
@@ -229,6 +231,7 @@ func verifyBestIndex(t *testing.T, ct *ClaimTrie, name string, idx uint32, claim
 	if claims > 0 {
 		r.Equal(idx, n.BestClaim.OutPoint.Index)
 	}
+	n.Close()
 }
 
 func TestRebuild(t *testing.T) {

--- a/claimtrie/cmd/cmd/node.go
+++ b/claimtrie/cmd/cmd/node.go
@@ -52,10 +52,11 @@ func NewNodeDumpCommand() *cobra.Command {
 			}
 			defer repo.Close()
 
-			changes, err := repo.LoadChanges([]byte(name))
+			changes, closer, err := repo.LoadChanges([]byte(name))
 			if err != nil {
 				return errors.Wrapf(err, "load commands")
 			}
+			defer closer()
 
 			for _, chg := range changes {
 				if chg.Height > height {

--- a/claimtrie/cmd/cmd/node.go
+++ b/claimtrie/cmd/cmd/node.go
@@ -108,6 +108,7 @@ func NewNodeReplayCommand() *cobra.Command {
 			}
 
 			showNode(n)
+			n.Close()
 			return nil
 		},
 	}

--- a/claimtrie/node/claim.go
+++ b/claimtrie/node/claim.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/lbryio/lbcd/chaincfg/chainhash"
 	"github.com/lbryio/lbcd/claimtrie/change"
@@ -31,6 +32,12 @@ type Claim struct {
 	Status   Status `msgpack:",omitempty"`
 	Sequence int32  `msgpack:",omitempty"`
 }
+
+func newClaim() interface{} {
+	return &Claim{}
+}
+
+var claimPool = sync.Pool{New: newClaim}
 
 func (c *Claim) setOutPoint(op wire.OutPoint) *Claim {
 	c.OutPoint = op

--- a/claimtrie/node/hashfork_manager.go
+++ b/claimtrie/node/hashfork_manager.go
@@ -15,6 +15,7 @@ func (nm *HashV2Manager) computeClaimHashes(name []byte) (*chainhash.Hash, int32
 	if err != nil || n == nil {
 		return nil, 0
 	}
+	defer n.Close()
 
 	n.SortClaimsByBid()
 	claimHashes := make([]*chainhash.Hash, 0, len(n.Claims))

--- a/claimtrie/node/manager.go
+++ b/claimtrie/node/manager.go
@@ -53,10 +53,11 @@ func (nm *BaseManager) NodeAt(height int32, name []byte) (*Node, error) {
 
 	n, changes, oldHeight := nm.cache.fetch(name, height)
 	if n == nil {
-		changes, err := nm.repo.LoadChanges(name)
+		changes, closer, err := nm.repo.LoadChanges(name)
 		if err != nil {
 			return nil, errors.Wrap(err, "in load changes")
 		}
+		defer closer()
 
 		if nm.tempChanges != nil { // making an assumption that we only ever have tempChanges for a single block
 			changes = append(changes, nm.tempChanges[string(name)]...)

--- a/claimtrie/node/manager.go
+++ b/claimtrie/node/manager.go
@@ -78,7 +78,9 @@ func (nm *BaseManager) NodeAt(height int32, name []byte) (*Node, error) {
 		if nm.tempChanges != nil { // making an assumption that we only ever have tempChanges for a single block
 			changes = append(changes, nm.tempChanges[string(name)]...)
 		}
+		old := n
 		n = n.Clone()
+		old.Close()
 		updated, err := nm.updateFromChanges(n, changes, height)
 		if err != nil {
 			if n != nil {

--- a/claimtrie/node/manager_test.go
+++ b/claimtrie/node/manager_test.go
@@ -147,6 +147,7 @@ func TestNodeSort(t *testing.T) {
 	r.True(OutPointLess(*out1, *out3))
 
 	n := New()
+	defer n.Close()
 	n.Claims = append(n.Claims, &Claim{OutPoint: *out1, AcceptedAt: 3, Amount: 3, ClaimID: change.ClaimID{1}})
 	n.Claims = append(n.Claims, &Claim{OutPoint: *out2, AcceptedAt: 3, Amount: 3, ClaimID: change.ClaimID{2}})
 	n.handleExpiredAndActivated(3)
@@ -167,6 +168,7 @@ func TestClaimSort(t *testing.T) {
 	param.ActiveParams.ExtendedClaimExpirationTime = 1000
 
 	n := New()
+	defer n.Close()
 	n.Claims = append(n.Claims, &Claim{OutPoint: *out2, AcceptedAt: 3, Amount: 3, ClaimID: change.ClaimID{2}, Status: Activated})
 	n.Claims = append(n.Claims, &Claim{OutPoint: *out3, AcceptedAt: 3, Amount: 2, ClaimID: change.ClaimID{3}, Status: Activated})
 	n.Claims = append(n.Claims, &Claim{OutPoint: *out3, AcceptedAt: 4, Amount: 2, ClaimID: change.ClaimID{4}, Status: Activated})

--- a/claimtrie/node/node.go
+++ b/claimtrie/node/node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"sync"
 
 	"github.com/lbryio/lbcd/claimtrie/change"
 	"github.com/lbryio/lbcd/claimtrie/param"
@@ -26,6 +27,27 @@ func (n *Node) HasActiveBestClaim() bool {
 	return n.BestClaim != nil && n.BestClaim.Status == Activated
 }
 
+var claimPool = sync.Pool{
+	New: func() interface{} {
+		return &Claim{}
+	},
+}
+
+func (n *Node) Close() {
+	n.BestClaim = nil
+	n.SupportSums = nil
+
+	for i := range n.Claims {
+		claimPool.Put(n.Claims[i])
+	}
+	n.Claims = nil
+
+	for i := range n.Supports {
+		claimPool.Put(n.Supports[i])
+	}
+	n.Supports = nil
+}
+
 func (n *Node) ApplyChange(chg change.Change, delay int32) error {
 
 	visibleAt := chg.VisibleHeight
@@ -35,17 +57,19 @@ func (n *Node) ApplyChange(chg change.Change, delay int32) error {
 
 	switch chg.Type {
 	case change.AddClaim:
-		c := &Claim{
-			OutPoint: chg.OutPoint,
-			Amount:   chg.Amount,
-			ClaimID:  chg.ClaimID,
-			// CreatedAt:  chg.Height,
-			AcceptedAt: chg.Height,
-			ActiveAt:   chg.Height + delay,
-			VisibleAt:  visibleAt,
-			Sequence:   int32(len(n.Claims)),
-		}
-		// old := n.Claims.find(byOut(chg.OutPoint)) // TODO: remove this after proving ResetHeight works
+		c := claimPool.Get().(*Claim)
+		// set all 8 fields on c as they aren't initialized to 0:
+		c.Status = Accepted
+		c.OutPoint = chg.OutPoint
+		c.Amount = chg.Amount
+		c.ClaimID = chg.ClaimID
+		// CreatedAt:  chg.Height,
+		c.AcceptedAt = chg.Height
+		c.ActiveAt = chg.Height + delay
+		c.VisibleAt = visibleAt
+		c.Sequence = int32(len(n.Claims))
+		// removed this after proving ResetHeight works:
+		// old := n.Claims.find(byOut(chg.OutPoint))
 		// if old != nil {
 		// return errors.Errorf("CONFLICT WITH EXISTING TXO! Name: %s, Height: %d", chg.Name, chg.Height)
 		// }
@@ -63,7 +87,6 @@ func (n *Node) ApplyChange(chg change.Change, delay int32) error {
 		// 'two' at 481100, 36a719a156a1df178531f3c712b8b37f8e7cc3b36eea532df961229d936272a1:0
 
 	case change.UpdateClaim:
-		// Find and remove the claim, which has just been spent.
 		c := n.Claims.find(byID(chg.ClaimID))
 		if c != nil && c.Status == Deactivated {
 
@@ -82,14 +105,18 @@ func (n *Node) ApplyChange(chg change.Change, delay int32) error {
 			LogOnce(fmt.Sprintf("Updating claim but missing existing claim with ID %s", chg.ClaimID))
 		}
 	case change.AddSupport:
-		n.Supports = append(n.Supports, &Claim{
-			OutPoint:   chg.OutPoint,
-			Amount:     chg.Amount,
-			ClaimID:    chg.ClaimID,
-			AcceptedAt: chg.Height,
-			ActiveAt:   chg.Height + delay,
-			VisibleAt:  visibleAt,
-		})
+		s := claimPool.Get().(*Claim)
+		// set all 8 fields on s:
+		s.Status = Accepted
+		s.OutPoint = chg.OutPoint
+		s.Amount = chg.Amount
+		s.ClaimID = chg.ClaimID
+		s.AcceptedAt = chg.Height
+		s.ActiveAt = chg.Height + delay
+		s.VisibleAt = visibleAt
+		s.Sequence = int32(len(n.Supports))
+
+		n.Supports = append(n.Supports, s)
 
 	case change.SpendSupport:
 		s := n.Supports.find(byOut(chg.OutPoint))

--- a/claimtrie/node/node.go
+++ b/claimtrie/node/node.go
@@ -14,12 +14,12 @@ type Node struct {
 	TakenOverAt int32     // The height at when the current BestClaim took over.
 	Claims      ClaimList // List of all Claims.
 	Supports    ClaimList // List of all Supports, including orphaned ones.
-	SupportSums map[string]int64
+	SupportSums map[change.ClaimID]int64
 }
 
 // New returns a new node.
 func New() *Node {
-	return &Node{SupportSums: map[string]int64{}}
+	return &Node{SupportSums: map[change.ClaimID]int64{}}
 }
 
 func (n *Node) HasActiveBestClaim() bool {
@@ -166,7 +166,7 @@ func (n *Node) handleExpiredAndActivated(height int32) int {
 	}
 
 	changes := 0
-	update := func(items ClaimList, sums map[string]int64) ClaimList {
+	update := func(items ClaimList, sums map[change.ClaimID]int64) ClaimList {
 		for i := 0; i < len(items); i++ {
 			c := items[i]
 			if c.Status == Accepted && c.ActiveAt <= height && c.VisibleAt <= height {
@@ -343,7 +343,7 @@ func (n *Node) SortClaimsByBid() {
 func (n *Node) Clone() *Node {
 	clone := New()
 	if n.SupportSums != nil {
-		clone.SupportSums = map[string]int64{}
+		clone.SupportSums = map[change.ClaimID]int64{}
 		for key, value := range n.SupportSums {
 			clone.SupportSums[key] = value
 		}

--- a/claimtrie/node/noderepo/noderepo_test.go
+++ b/claimtrie/node/noderepo/noderepo_test.go
@@ -92,8 +92,9 @@ func testNodeRepo(t *testing.T, repo node.Repo, setup, cleanup func()) {
 		err := repo.AppendChanges(tt.changes)
 		r.NoError(err)
 
-		changes, err := repo.LoadChanges(testNodeName1)
+		changes, closer, err := repo.LoadChanges(testNodeName1)
 		r.NoError(err)
+		defer closer()
 		r.Equalf(tt.expected, changes[:len(tt.expected)], tt.name)
 
 		cleanup()
@@ -150,8 +151,9 @@ func testNodeRepo(t *testing.T, repo node.Repo, setup, cleanup func()) {
 			r.NoError(err)
 		}
 
-		changes, err := repo.LoadChanges(testNodeName1)
+		changes, closer, err := repo.LoadChanges(testNodeName1)
 		r.NoError(err)
+		defer closer()
 		r.Equalf(tt.expected, changes[:len(tt.expected)], tt.name)
 
 		cleanup()

--- a/claimtrie/node/normalizing_manager.go
+++ b/claimtrie/node/normalizing_manager.go
@@ -72,6 +72,7 @@ func (nm *NormalizingManager) addNormalizationForkChangesIfNecessary(height int3
 		if err != nil || n == nil {
 			return true
 		}
+		defer n.Close()
 		for _, c := range n.Claims {
 			nm.Manager.AppendChange(change.Change{
 				Type:          change.AddClaim,

--- a/claimtrie/node/repo.go
+++ b/claimtrie/node/repo.go
@@ -13,7 +13,9 @@ type Repo interface {
 
 	// LoadChanges loads changes of a node up to (includes) the specified height.
 	// If no changes found, both returned slice and error will be nil.
-	LoadChanges(name []byte) ([]change.Change, error)
+	// The returned closer func() should be called to release changes after
+	// work on them is finished.
+	LoadChanges(name []byte) (changes []change.Change, closer func(), err error)
 
 	DropChanges(name []byte, finalHeight int32) error
 

--- a/rpcclaimtrie.go
+++ b/rpcclaimtrie.go
@@ -106,6 +106,7 @@ func handleGetClaimsForName(s *rpcServer, cmd interface{}, _ <-chan struct{}) (i
 			Message: "Message: " + err.Error(),
 		}
 	}
+	defer n.Close()
 
 	var results []btcjson.ClaimResult
 	for i := range n.Claims {
@@ -140,6 +141,7 @@ func handleGetClaimsForNameByID(s *rpcServer, cmd interface{}, _ <-chan struct{}
 			Message: "Message: " + err.Error(),
 		}
 	}
+	defer n.Close()
 
 	var results []btcjson.ClaimResult
 	for i := 0; i < len(n.Claims); i++ {
@@ -179,6 +181,7 @@ func handleGetClaimsForNameByBid(s *rpcServer, cmd interface{}, _ <-chan struct{
 			Message: "Message: " + err.Error(),
 		}
 	}
+	defer n.Close()
 
 	var results []btcjson.ClaimResult
 	for _, b := range c.Bids { // claims are already sorted in bid order
@@ -215,6 +218,7 @@ func handleGetClaimsForNameBySeq(s *rpcServer, cmd interface{}, _ <-chan struct{
 			Message: "Message: " + err.Error(),
 		}
 	}
+	defer n.Close()
 
 	sm := map[int32]bool{}
 	for _, seq := range c.Sequences {


### PR DESCRIPTION
Unbundled from PR https://github.com/lbryio/lbcd/pull/43

See that for usage/testing.

Based on work by @BrannonKing in mem_pressure_try_2 and reduce_memory_pressure.

The commits 84828907593e597856f977af18649637bd5b8c6c and 787098e2a2f4692c7c3e6eab1a1ba25d00a54ae0 are newly added to claw back costs from node cache and node.Clone().