### PR TITLE
Allow environment var GOMAXPROCS=<N> to override NumCPU().

### DIFF
--- a/claimtrie/claimtrie.go
+++ b/claimtrie/claimtrie.go
@@ -449,7 +449,7 @@ func (ct *ClaimTrie) makeNameHashNext(names [][]byte, all bool, interrupt <-chan
 		wg.Done()
 	}
 
-	threads := int(0.8 * float32(runtime.NumCPU()))
+	threads := int(0.8 * float32(runtime.GOMAXPROCS(0)))
 	if threads < 1 {
 		threads = 1
 	}


### PR DESCRIPTION
Default value of GOMAXPROCS is NumCPU(), so ordinary behavior does not change.

However, this allows tuning the number of threads used for claimtrie rebuild.