### PR TITLE
Claimtrie progress logging.

### DIFF
--- a/claimtrie/claimtrie.go
+++ b/claimtrie/claimtrie.go
@@ -49,6 +49,9 @@ type ClaimTrie struct {
 
 	// Registrered cleanup functions which are invoked in the Close() in reverse order.
 	cleanups []func() error
+
+	// nameLogger communicates progress of claimtrie rebuild.
+	nameLogger *nameProgressLogger
 }
 
 func New(cfg config.Config) (*ClaimTrie, error) {
@@ -345,15 +348,19 @@ func (ct *ClaimTrie) ResetHeight(height int32) error {
 func (ct *ClaimTrie) runFullTrieRebuild(names [][]byte, interrupt <-chan struct{}) {
 	var nhns chan NameHashNext
 	if names == nil {
-		node.LogOnce("Building the entire claim trie in RAM...")
-
+		node.Log("Building the entire claim trie in RAM...")
+		ct.nameLogger = newNameProgressLogger("Processed", node.GetLogger())
 		nhns = ct.makeNameHashNext(nil, true, interrupt)
 	} else {
+		ct.nameLogger = nil
 		nhns = ct.makeNameHashNext(names, false, interrupt)
 	}
 
 	for nhn := range nhns {
 		ct.merkleTrie.Update(nhn.Name, nhn.Hash, false)
+		if ct.nameLogger != nil {
+			ct.nameLogger.LogName(nhn.Name)
+		}
 	}
 }
 

--- a/claimtrie/logger.go
+++ b/claimtrie/logger.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package netsync
+
+import (
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btclog"
+	btcutil "github.com/lbryio/lbcutil"
+)
+
+// blockProgressLogger provides periodic logging for other services in order
+// to show users progress of certain "actions" involving some or all current
+// blocks. Ex: syncing to best chain, indexing all blocks, etc.
+type blockProgressLogger struct {
+	receivedLogBlocks int64
+	receivedLogTx     int64
+	lastBlockLogTime  time.Time
+
+	subsystemLogger btclog.Logger
+	progressAction  string
+	sync.Mutex
+}
+
+// newBlockProgressLogger returns a new block progress logger.
+// The progress message is templated as follows:
+//  {progressAction} {numProcessed} {blocks|block} in the last {timePeriod}
+//  ({numTxs}, height {lastBlockHeight}, {lastBlockTimeStamp})
+func newBlockProgressLogger(progressMessage string, logger btclog.Logger) *blockProgressLogger {
+	return &blockProgressLogger{
+		lastBlockLogTime: time.Now(),
+		progressAction:   progressMessage,
+		subsystemLogger:  logger,
+	}
+}
+
+// LogBlockHeight logs a new block height as an information message to show
+// progress to the user. In order to prevent spam, it limits logging to one
+// message every 10 seconds with duration and totals included.
+func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
+	b.Lock()
+	defer b.Unlock()
+
+	b.receivedLogBlocks++
+	b.receivedLogTx += int64(len(block.MsgBlock().Transactions))
+
+	now := time.Now()
+	duration := now.Sub(b.lastBlockLogTime)
+	if duration < time.Second*10 {
+		return
+	}
+
+	// Truncate the duration to 10s of milliseconds.
+	durationMillis := int64(duration / time.Millisecond)
+	tDuration := 10 * time.Millisecond * time.Duration(durationMillis/10)
+
+	// Log information about new block height.
+	blockStr := "blocks"
+	if b.receivedLogBlocks == 1 {
+		blockStr = "block"
+	}
+	txStr := "transactions"
+	if b.receivedLogTx == 1 {
+		txStr = "transaction"
+	}
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s)",
+		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
+		txStr, block.Height(), block.MsgBlock().Header.Timestamp)
+
+	b.receivedLogBlocks = 0
+	b.receivedLogTx = 0
+	b.lastBlockLogTime = now
+}
+
+func (b *blockProgressLogger) SetLastLogTime(time time.Time) {
+	b.lastBlockLogTime = time
+}

--- a/claimtrie/node/log.go
+++ b/claimtrie/node/log.go
@@ -29,6 +29,10 @@ func UseLogger(logger btclog.Logger) {
 	log = logger
 }
 
+func GetLogger() btclog.Logger {
+	return log
+}
+
 var loggedStrings = map[string]bool{} // is this gonna get too large?
 var loggedStringsMutex sync.Mutex
 
@@ -39,6 +43,10 @@ func LogOnce(s string) {
 		return
 	}
 	loggedStrings[s] = true
+	log.Info(s)
+}
+
+func Log(s string) {
 	log.Info(s)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/lbryio/lbcd/issues/50

I copied claimtrie/logger.go from netsync/blocklogger.go. Copyright comment from there left intact. Let me know if there is a better way to handle derivative works like this.

I did not find a way to handle percentage progress... The pebble stats API stuff seems to be private, so I did not try to use that to estimate the number of records.

Example output:
```
2022-06-14 12:58:59.093 [INF] MAIN: Version 0.0.0-local.0+b17aee2e1cf72d0e99307291a77c4ef164c4c9c7-dirty
2022-06-14 12:58:59.094 [INF] MAIN: Loading block database from '/Users/swdev1/Library/Application Support/Lbcd/data/mainnet/blocks_ffldb'
2022-06-14 12:58:59.363 [INF] MAIN: Block database loaded
2022-06-14 12:59:02.364 [INF] SRVR: Can't discover UPnP-enabled device: write udp4 0.0.0.0:61487->239.255.255.250:1900: i/o timeout
2022-06-14 12:59:02.371 [INF] INDX: Transaction index is enabled
2022-06-14 12:59:02.372 [INF] INDX: Committed filter index is enabled
2022-06-14 12:59:02.819 [INF] LBRY: Normalizing strings via Go. Casefold and NFD table versions: 11.0.0 (from ICU 63.2)
2022-06-14 12:59:02.819 [INF] LBRY: Building the entire claim trie in RAM...
2022-06-14 12:59:05.991 [INF] LBRY: Spending claim but missing existing claim with TXO bd183d94dc0b2c38d500838f4ab7c93b643123f46e87214d3e37f5e9e0d4baf5:0, Name: 1791l-trumpcnn, ID: 6a28cbbe64c3c54113770705c928e80a138ddae9
2022-06-14 12:59:12.819 [INF] LBRY: Processed 2452877 names in the last 10s (total 2452877)
2022-06-14 12:59:22.819 [INF] LBRY: Processed 2414530 names in the last 10s (total 4867407)
2022-06-14 12:59:32.819 [INF] LBRY: Processed 1976208 names in the last 10s (total 6843615)
2022-06-14 12:59:39.463 [INF] MAIN: RAM: using 1.5 GB with 3.6 available, DISK: using 123.0 GB with 1164.9 available
2022-06-14 12:59:42.820 [INF] LBRY: Processed 2051309 names in the last 10s (total 8894924)
2022-06-14 12:59:51.325 [INF] LBRY: Spending claim but missing existing claim with TXO 546a1b99218f5935d6d11d6a5632ba199b24d6dbb6c07e75bea1089eee23987d:0, Name: ggminingpool-xzc, ID: 0b9e8ea179d6f68d3b37ab0e636af6ab1b93b52e
2022-06-14 12:59:51.328 [INF] LBRY: Spending claim but missing existing claim with TXO 5dff52209029a63547f8805c3e92fce87e3744a15f6539a12011fe0c421ca132:0, Name: ggminingpoolxzc, ID: 3fa8d7113bd4873e79ec02019bea3c7840f0deee
2022-06-14 12:59:52.820 [INF] LBRY: Processed 2101310 names in the last 10s (total 10996234)
2022-06-14 13:00:02.820 [INF] LBRY: Processed 1793583 names in the last 10s (total 12789817)
2022-06-14 13:00:12.820 [INF] LBRY: Processed 1623173 names in the last 10s (total 14412990)
2022-06-14 13:00:19.524 [INF] MAIN: RAM: using 2.5 GB with 2.7 available, DISK: using 123.0 GB with 1164.9 available
2022-06-14 13:00:21.888 [INF] LBRY: Spending claim but missing existing claim with TXO 022a25b42e0327d6bf7a741cd3bae34404453549635d916e5b05eb15edb05019:1, Name: redbullfourthphase, ID: f054e085e8d38c0a0e63a472b033e42d437a4014
2022-06-14 13:00:22.820 [INF] LBRY: Processed 1598781 names in the last 10s (total 16011771)
2022-06-14 13:00:32.820 [INF] LBRY: Processed 1581485 names in the last 10s (total 17593256)
2022-06-14 13:00:35.884 [INF] LBRY: Spending claim but missing existing claim with TXO d549351f731019573d921f5db8e2844449edf3011073b3e5f4ce9b0d9aee5490:1, Name: timcast-sweden-day1, ID: 247895d4b9389b74038ea5a4fd807cafc97ede53
2022-06-14 13:00:38.586 [INF] LBRY: Spending claim but missing existing claim with TXO 36a719a156a1df178531f3c712b8b37f8e7cc3b36eea532df961229d936272a1:0, Name: two, ID: bb6168c9a56286999c7c938c7b8c5afb221d38d0
2022-06-14 13:00:42.821 [INF] LBRY: Processed 1562595 names in the last 10s (total 19155851)
2022-06-14 13:00:52.821 [INF] LBRY: Processed 1614307 names in the last 10s (total 20770158)
2022-06-14 13:00:59.454 [INF] MAIN: RAM: using 3.4 GB with 2.8 available, DISK: using 123.0 GB with 1164.9 available
2022-06-14 13:01:07.179 [INF] CHAN: Loading block index...
2022-06-14 13:01:20.621 [INF] CHAN: Chain state (height 1176372, hash eab6338179a6b6b00d7349ec2248c30b025dcb91e1168ad888edd66d27d958f0, totaltx 80626871, work 44778056400671924494304)

```