### PR TITLE
Rpc mempool: Support more fields in getmempoolinfo result.

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -340,8 +340,8 @@ type GetMempoolInfoResult struct {
 	Size             int64   `json:"size"`             // Current tx count
 	Bytes            int64   `json:"bytes"`            // Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted
 	Usage            int64   `json:"usage"`            // Total memory usage for the mempool
-	TotalFee         float64 `json:"total_fee"`        // Total fees for the mempool in BTC, ignoring modified fees through prioritizetransaction
-	MemPoolMinFee    float64 `json:"mempoolminfee"`    // Minimum fee rate in BTC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee
+	TotalFee         float64 `json:"total_fee"`        // Total fees for the mempool in LBC, ignoring modified fees through prioritizetransaction
+	MemPoolMinFee    float64 `json:"mempoolminfee"`    // Minimum fee rate in LBC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee
 	MinRelayTxFee    float64 `json:"minrelaytxfee"`    // Current minimum relay fee for transactions
 	UnbroadcastCount int64   `json:"unbroadcastcount"` // Current number of transactions that haven't passed initial broadcast yet
 }

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -343,6 +343,7 @@ type GetMempoolInfoResult struct {
 	TotalFee         float64 `json:"total_fee"`        // Total fees for the mempool in BTC, ignoring modified fees through prioritizetransaction
 	MemPoolMinFee    float64 `json:"mempoolminfee"`    // Minimum fee rate in BTC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee
 	MinRelayTxFee    float64 `json:"minrelaytxfee"`    // Current minimum relay fee for transactions
+	UnbroadcastCount int64   `json:"unbroadcastcount"` // Current number of transactions that haven't passed initial broadcast yet
 }
 
 // NetworksResult models the networks data from the getnetworkinfo command.

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -337,8 +337,12 @@ type GetChainTipsResult struct {
 // GetMempoolInfoResult models the data returned from the getmempoolinfo
 // command.
 type GetMempoolInfoResult struct {
-	Size  int64 `json:"size"`
-	Bytes int64 `json:"bytes"`
+	Size             int64   `json:"size"`             // Current tx count
+	Bytes            int64   `json:"bytes"`            // Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted
+	Usage            int64   `json:"usage"`            // Total memory usage for the mempool
+	TotalFee         float64 `json:"total_fee"`        // Total fees for the mempool in BTC, ignoring modified fees through prioritizetransaction
+	MemPoolMinFee    float64 `json:"mempoolminfee"`    // Minimum fee rate in BTC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee
+	MinRelayTxFee    float64 `json:"minrelaytxfee"`    // Current minimum relay fee for transactions
 }
 
 // NetworksResult models the networks data from the getnetworkinfo command.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -179,14 +179,14 @@ type TxDesc struct {
 func (txD *TxDesc) incr(info *aggregateInfo) {
 	info.totalCount += 1
 	info.totalBytes += int64(txD.Tx.MsgTx().SerializeSize())
-	info.totalMem += int64(dynamicMemUsage(reflect.ValueOf(txD), false, 0))
+	info.totalMem += int64(dynamicMemUsage(reflect.ValueOf(txD)))
 	info.totalFee += txD.Fee
 }
 
 func (txD *TxDesc) decr(info *aggregateInfo) {
 	info.totalCount -= 1
 	info.totalBytes -= int64(txD.Tx.MsgTx().SerializeSize())
-	info.totalMem -= int64(dynamicMemUsage(reflect.ValueOf(txD), false, 0))
+	info.totalMem -= int64(dynamicMemUsage(reflect.ValueOf(txD)))
 	info.totalFee -= txD.Fee
 }
 
@@ -202,13 +202,13 @@ type orphanTx struct {
 func (otx *orphanTx) incr(info *aggregateInfo) {
 	info.totalCount += 1
 	info.totalBytes += int64(otx.tx.MsgTx().SerializeSize())
-	info.totalMem += int64(dynamicMemUsage(reflect.ValueOf(otx), true, 0))
+	info.totalMem += int64(dynamicMemUsage(reflect.ValueOf(otx)))
 }
 
 func (otx *orphanTx) decr(info *aggregateInfo) {
 	info.totalCount -= 1
 	info.totalBytes -= int64(otx.tx.MsgTx().SerializeSize())
-	info.totalMem -= int64(dynamicMemUsage(reflect.ValueOf(otx), false, 0))
+	info.totalMem -= int64(dynamicMemUsage(reflect.ValueOf(otx)))
 }
 
 // TxPool is used as a source of transactions that need to be mined into blocks

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -21,6 +21,12 @@ import (
 	btcutil "github.com/lbryio/lbcutil"
 )
 
+func init() {
+	// Toggle assert & debug messages when running tests.
+	dynamicMemUsageAssert = true
+	dynamicMemUsageDebug = false
+}
+
 // fakeChain is used by the pool harness to provide generated test utxos and
 // a current faked chain height to the pool callbacks.  This, in turn, allows
 // transactions to appear as though they are spending completely valid utxos.

--- a/mempool/memusage.go
+++ b/mempool/memusage.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"reflect"
+)
+
+func dynamicMemUsage(v reflect.Value, debug bool, level int) uintptr {
+	t := v.Type()
+	bytes := t.Size()
+	if debug {
+		println("[", level, "]", t.Kind().String(), "(", t.String(), ") ->", t.Size())
+	}
+
+	// For complex types, we need to peek inside slices/arrays/structs/maps and chase pointers.
+	switch t.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if !v.IsNil() {
+			bytes += dynamicMemUsage(v.Elem(), debug, level+1)
+		}
+	case reflect.Array, reflect.Slice:
+		for j := 0; j < v.Len(); j++ {
+			vi := v.Index(j)
+			k := vi.Type().Kind()
+			if debug {
+				println("[", level, "] index:", j, "kind:", k.String())
+			}
+			elemB := uintptr(0)
+			if t.Kind() == reflect.Array {
+				if (k == reflect.Pointer || k == reflect.Interface) && !vi.IsNil() {
+					elemB += dynamicMemUsage(vi.Elem(), debug, level+1)
+				}
+			} else { // slice
+				elemB += dynamicMemUsage(vi, debug, level+1)
+			}
+			if k == reflect.Uint8 {
+				// short circuit for byte slice/array
+				bytes += elemB * uintptr(v.Len())
+				if debug {
+					println("...", v.Len(), "elements")
+				}
+				break
+			}
+			bytes += elemB
+		}
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			vk := iter.Key()
+			vv := iter.Value()
+			if debug {
+				println("[", level, "] key:", vk.Type().Kind().String())
+			}
+			bytes += dynamicMemUsage(vk, debug, level+1)
+			if debug {
+				println("[", level, "] value:", vv.Type().Kind().String())
+			}
+			bytes += dynamicMemUsage(vv, debug, level+1)
+			if debug {
+				println("...", v.Len(), "map elements")
+			}
+			debug = false
+		}
+	case reflect.Struct:
+		for _, f := range reflect.VisibleFields(t) {
+			vf := v.FieldByIndex(f.Index)
+			k := vf.Type().Kind()
+			if debug {
+				println("[", level, "] field:", f.Name, "kind:", k.String())
+			}
+			if (k == reflect.Pointer || k == reflect.Interface) && !vf.IsNil() {
+				bytes += dynamicMemUsage(vf.Elem(), debug, level+1)
+			} else if k == reflect.Array || k == reflect.Slice {
+				bytes -= vf.Type().Size()
+				bytes += dynamicMemUsage(vf, debug, level+1)
+			}
+		}
+	}
+
+	return bytes
+}

--- a/mempool/memusage.go
+++ b/mempool/memusage.go
@@ -5,82 +5,83 @@
 package mempool
 
 import (
+	"fmt"
 	"reflect"
 )
 
+var (
+	dynamicMemUsageAssert   = false
+	dynamicMemUsageDebug    = false
+	dynamicMemUsageMaxDepth = 10
+)
+
 func dynamicMemUsage(v reflect.Value) uintptr {
-	return _dynamicMemUsage(v, false, 0)
+	return dynamicMemUsageCrawl(v, 0)
 }
 
-func _dynamicMemUsage(v reflect.Value, debug bool, level int) uintptr {
+func dynamicMemUsageCrawl(v reflect.Value, depth int) uintptr {
 	t := v.Type()
 	bytes := t.Size()
-	if debug {
-		println("[", level, "]", t.Kind().String(), "(", t.String(), ") ->", t.Size())
+	if dynamicMemUsageDebug {
+		println("[", depth, "]", t.Kind().String(), "(", t.String(), ") ->", t.Size())
 	}
 
-	// For complex types, we need to peek inside slices/arrays/structs/maps and chase pointers.
+	if depth >= dynamicMemUsageMaxDepth {
+		if dynamicMemUsageAssert {
+			panic("crawl reached maximum depth")
+		}
+		return bytes
+	}
+
+	// For complex types, we need to peek inside slices/arrays/structs and chase pointers.
 	switch t.Kind() {
 	case reflect.Pointer, reflect.Interface:
 		if !v.IsNil() {
-			bytes += _dynamicMemUsage(v.Elem(), debug, level+1)
+			bytes += dynamicMemUsageCrawl(v.Elem(), depth+1)
 		}
 	case reflect.Array, reflect.Slice:
 		for j := 0; j < v.Len(); j++ {
 			vi := v.Index(j)
 			k := vi.Type().Kind()
-			if debug {
-				println("[", level, "] index:", j, "kind:", k.String())
+			if dynamicMemUsageDebug {
+				println("[", depth, "] index:", j, "kind:", k.String())
 			}
-			elemB := uintptr(0)
+			elemBytes := uintptr(0)
 			if t.Kind() == reflect.Array {
 				if (k == reflect.Pointer || k == reflect.Interface) && !vi.IsNil() {
-					elemB += _dynamicMemUsage(vi.Elem(), debug, level+1)
+					elemBytes += dynamicMemUsageCrawl(vi.Elem(), depth+1)
 				}
 			} else { // slice
-				elemB += _dynamicMemUsage(vi, debug, level+1)
+				elemBytes += dynamicMemUsageCrawl(vi, depth+1)
 			}
 			if k == reflect.Uint8 {
 				// short circuit for byte slice/array
-				bytes += elemB * uintptr(v.Len())
-				if debug {
+				bytes += elemBytes * uintptr(v.Len())
+				if dynamicMemUsageDebug {
 					println("...", v.Len(), "elements")
 				}
 				break
 			}
-			bytes += elemB
-		}
-	case reflect.Map:
-		iter := v.MapRange()
-		for iter.Next() {
-			vk := iter.Key()
-			vv := iter.Value()
-			if debug {
-				println("[", level, "] key:", vk.Type().Kind().String())
-			}
-			bytes += _dynamicMemUsage(vk, debug, level+1)
-			if debug {
-				println("[", level, "] value:", vv.Type().Kind().String())
-			}
-			bytes += _dynamicMemUsage(vv, debug, level+1)
-			if debug {
-				println("...", v.Len(), "map elements")
-			}
-			debug = false
+			bytes += elemBytes
 		}
 	case reflect.Struct:
 		for _, f := range reflect.VisibleFields(t) {
 			vf := v.FieldByIndex(f.Index)
 			k := vf.Type().Kind()
-			if debug {
-				println("[", level, "] field:", f.Name, "kind:", k.String())
+			if dynamicMemUsageDebug {
+				println("[", depth, "] field:", f.Name, "kind:", k.String())
 			}
 			if (k == reflect.Pointer || k == reflect.Interface) && !vf.IsNil() {
-				bytes += _dynamicMemUsage(vf.Elem(), debug, level+1)
+				bytes += dynamicMemUsageCrawl(vf.Elem(), depth+1)
 			} else if k == reflect.Array || k == reflect.Slice {
 				bytes -= vf.Type().Size()
-				bytes += _dynamicMemUsage(vf, debug, level+1)
+				bytes += dynamicMemUsageCrawl(vf, depth+1)
 			}
+		}
+	case reflect.Uint8:
+	default:
+		if dynamicMemUsageAssert {
+			panic(fmt.Sprintf("unsupported kind: %v", t.Kind()))
 		}
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3748,6 +3748,7 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	// Keep track of all the sendrawtransaction request txns so that they
 	// can be rebroadcast if they don't make their way into a block.
 	txD := acceptedTxs[0]
+	s.cfg.TxMemPool.AddUnbroadcastTx(txD.Tx.Hash())
 	iv := wire.NewInvVect(wire.InvTypeTx, txD.Tx.Hash())
 	s.cfg.ConnMgr.AddRebroadcastInventory(iv, txD)
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2468,19 +2468,7 @@ func handleGetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 
 // handleGetMempoolInfo implements the getmempoolinfo command.
 func handleGetMempoolInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	mempoolTxns := s.cfg.TxMemPool.TxDescs()
-
-	var numBytes int64
-	for _, txD := range mempoolTxns {
-		numBytes += int64(txD.Tx.MsgTx().SerializeSize())
-	}
-
-	ret := &btcjson.GetMempoolInfoResult{
-		Size:  int64(len(mempoolTxns)),
-		Bytes: numBytes,
-	}
-
-	return ret, nil
+	return s.cfg.TxMemPool.MempoolInfo(), nil
 }
 
 // handleGetMempoolEntry implements the getmempoolentry command.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -453,8 +453,12 @@ var helpDescsEnUS = map[string]string{
 	"getmempoolinfo--synopsis": "Returns memory pool information",
 
 	// GetMempoolInfoResult help.
-	"getmempoolinforesult-bytes": "Size in bytes of the mempool",
-	"getmempoolinforesult-size":  "Number of transactions in the mempool",
+	"getmempoolinforesult-bytes":            "Size in bytes of the mempool",
+	"getmempoolinforesult-size":             "Number of transactions in the mempool",
+	"getmempoolinforesult-usage":            "Total memory usage for the mempool",
+	"getmempoolinforesult-total_fee":        "Total fees for the mempool in LBC, ignoring modified fees through prioritizetransaction",
+	"getmempoolinforesult-mempoolminfee":    "Minimum fee rate in LBC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee",
+	"getmempoolinforesult-minrelaytxfee":    "Current minimum relay fee for transactions",
 
 	// GetMiningInfoResult help.
 	"getmininginforesult-blocks":             "Height of the latest best block",

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -459,6 +459,7 @@ var helpDescsEnUS = map[string]string{
 	"getmempoolinforesult-total_fee":        "Total fees for the mempool in LBC, ignoring modified fees through prioritizetransaction",
 	"getmempoolinforesult-mempoolminfee":    "Minimum fee rate in LBC/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee",
 	"getmempoolinforesult-minrelaytxfee":    "Current minimum relay fee for transactions",
+	"getmempoolinforesult-unbroadcastcount": "Current number of transactions that haven't passed initial broadcast yet",
 
 	// GetMiningInfoResult help.
 	"getmininginforesult-blocks":             "Height of the latest best block",

--- a/server.go
+++ b/server.go
@@ -699,6 +699,11 @@ func (sp *serverPeer) OnGetData(_ *peer.Peer, msg *wire.MsgGetData) {
 			if i == len(msg.InvList)-1 && c != nil {
 				<-c
 			}
+		} else if iv.Type == wire.InvTypeWitnessTx || iv.Type == wire.InvTypeTx {
+			// We interpret fulfilling a GETDATA for a transaction as a
+			// successful initial broadcast and remove it from our
+			// unbroadcast set.
+			sp.server.txMemPool.RemoveUnbroadcastTx(&iv.Hash)
 		}
 		numAdded++
 		waitChan = c


### PR DESCRIPTION
Fixes https://github.com/lbryio/lbcd/issues/60

Field "loaded" only makes sense if the Mempool is being saved/loaded on restart. I don't see that happening.
Field "maxmempool" would need more configuration infrastructure, and could be supported if that were added.

The "usage" (memory) and "unbroadcastcount" were my attempt to mimic what's done in C++ bitcoin (https://github.com/bitcoin/bitcoin).

Manual test, showing rollover back to near 0 size, apparently on new block acceptance.
```
Mac-mini lbcd % ./lbcctl --rpcuser=xxx --rpcpass=yyy getmempoolinfo
{
  "size": 267,
  "bytes": 256195,
  "usage": 347789,
  "total_fee": 0.21047744,
  "mempoolminfee": 0.00001,
  "minrelaytxfee": 0.00001,
  "unbroadcastcount": 0
}
Mac-mini lbcd % ./lbcctl --rpcuser=xxx --rpcpass=yyy getmempoolinfo
{
  "size": 3,
  "bytes": 2260,
  "usage": 3223,
  "total_fee": 0.001164,
  "mempoolminfee": 0.00001,
  "minrelaytxfee": 0.00001,
  "unbroadcastcount": 0
}
```

Investigating automated tests next...