### PR TITLE
mining: include 'segwit' rule when no segwit txns in GBT

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1900,6 +1900,8 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 	if template.WitnessCommitment != nil {
 		reply.DefaultWitnessCommitment = hex.EncodeToString(template.WitnessCommitment)
 		reply.Rules = append(reply.Rules, "!segwit")
+	} else {
+		reply.Rules = append(reply.Rules, "segwit")
 	}
 
 	if useCoinbaseValue {


### PR DESCRIPTION
According to the BIP0009, all active softfork deployment should
be included in the rules.

We add the '!' to indicate the enforcement if the template has
any segwit transactions in it. Otherwise, plain `segwit` is fine.