### PR TITLE
Revert "mining: return witness_script instead of raw witness_c…"

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -868,7 +868,7 @@ mempoolLoop:
 }
 
 // AddWitnessCommitment adds the witness commitment as an OP_RETURN outpout
-// within the coinbase tx.  The witness script is returned.
+// within the coinbase tx.  The raw commitment is returned.
 func AddWitnessCommitment(coinbaseTx *btcutil.Tx,
 	blockTxns []*btcutil.Tx) []byte {
 
@@ -907,7 +907,7 @@ func AddWitnessCommitment(coinbaseTx *btcutil.Tx,
 	coinbaseTx.MsgTx().TxOut = append(coinbaseTx.MsgTx().TxOut,
 		commitmentOutput)
 
-	return witnessScript
+	return witnessCommitment
 }
 
 // UpdateBlockTime updates the timestamp in the header of the passed block to


### PR DESCRIPTION
The original code is correct. It should be updated on the yimmp side.

This reverts commit d20a2e53b429138363af857653f9fd89deb71c6e.