### PR TITLE
policy: relax dust thrashold to 1000 dewies/kB, which aligns to lbrycrd

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -249,7 +249,7 @@ func GetDustThreshold(txOut *wire.TxOut) int64 {
 		totalSize += 107
 	}
 
-	return 3 * int64(totalSize)
+	return int64(totalSize)
 }
 
 // IsDust returns whether or not the passed transaction output amount is
@@ -264,7 +264,7 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	}
 
 	// The output is considered dust if the cost to the network to spend the
-	// coins is more than 1/3 of the minimum free transaction relay fee.
+	// coins is more than the minimum free transaction relay fee.
 	// minFreeTxRelayFee is in Satoshi/KB, so multiply by 1000 to
 	// convert to bytes.
 	//
@@ -273,7 +273,7 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	// fee of 1000, this equates to values less than 546 satoshi being
 	// considered dust.
 	//
-	// The following is equivalent to (value/totalSize) * (1/3) * 1000
+	// The following is equivalent to (value/totalSize) * 1000
 	// without needing to do floating point math.
 	if txOut.Value > dustCap {
 		return false

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -233,14 +233,14 @@ func TestDust(t *testing.T) {
 			true,
 		},
 		{
-			"38 byte public key script with value 584",
-			wire.TxOut{Value: 584, PkScript: pkScript},
+			"38 byte public key script with value 194",
+			wire.TxOut{Value: 194, PkScript: pkScript},
 			1000,
 			true,
 		},
 		{
-			"38 byte public key script with value 585",
-			wire.TxOut{Value: 585, PkScript: pkScript},
+			"38 byte public key script with value 195",
+			wire.TxOut{Value: 195, PkScript: pkScript},
 			1000,
 			false,
 		},


### PR DESCRIPTION
An output is considered dust if the cost to the network to spend the
coins is more than 1/3 of the minimum free transaction relay fee, which
has a default rate of 1000 satoshis/kb

bitcoind refactored dust threshold calculation, which removed the
multiply factor of 3 from the code, but increased the DUST_RELAY_TX_FEE
from 1000 to 3000 (satoshi/kb).

lbrycrd adopted the refactored code but also kept the rate to
1000 dewies/kB, which means:

    An output is considered dust if the cost to the network to spend the
    coins is more than the minimum free transaction relay fee.

This commit updates lbcd to align the policy.