### PR TITLE
mining: always returns .coinbasevalue in getblocktemplate

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2368,7 +2368,6 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 
 	if useCoinbaseValue {
 		reply.CoinbaseAux = gbtCoinbaseAux
-		reply.CoinbaseValue = &msgBlock.Transactions[0].TxOut[0].Value
 	} else {
 		// Ensure the template has a valid payment address associated
 		// with it when a full coinbase is requested.
@@ -2400,6 +2399,9 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 
 		reply.CoinbaseTxn = &resultTx
 	}
+
+	// Return coinbasevalue anyway as lbrycrd and bitcoind do.
+	reply.CoinbaseValue = &msgBlock.Transactions[0].TxOut[0].Value
 
 	return &reply, nil
 }


### PR DESCRIPTION
Fix #96 

Although the BIPs specify that `coinbasetxn` and `coinbasevalue` are mutually exclusive, both the latest bitcoind (22.0.0) and lbrycrd (0.17.3) returns .coinbasevalue regardless if 'coinbasetxn' is specified in the capabilities.

We'll make lbcd behave the same for compatibility.