### PR TITLE
rpc: update rpc cmd requests to support multi-account

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -176,12 +176,13 @@ func NewGetAccountCmd(address string) *GetAccountCmd {
 
 // GetAccountAddressCmd defines the getaccountaddress JSON-RPC command.
 type GetAccountAddressCmd struct {
-	Account string
+	Account     *string `jsonrpcdefault:"\"default\""`
+	AddressType *string `jsonrpcdefault:"\"legacy\""`
 }
 
 // NewGetAccountAddressCmd returns a new instance which can be used to issue a
 // getaccountaddress JSON-RPC command.
-func NewGetAccountAddressCmd(account string) *GetAccountAddressCmd {
+func NewGetAccountAddressCmd(account *string) *GetAccountAddressCmd {
 	return &GetAccountAddressCmd{
 		Account: account,
 	}
@@ -189,12 +190,13 @@ func NewGetAccountAddressCmd(account string) *GetAccountAddressCmd {
 
 // GetAddressesByAccountCmd defines the getaddressesbyaccount JSON-RPC command.
 type GetAddressesByAccountCmd struct {
-	Account string
+	Account     *string `jsonrpcdefault:"\"default\""`
+	AddressType *string `jsonrpcdefault:"\"*\""`
 }
 
 // NewGetAddressesByAccountCmd returns a new instance which can be used to issue
 // a getaddressesbyaccount JSON-RPC command.
-func NewGetAddressesByAccountCmd(account string) *GetAddressesByAccountCmd {
+func NewGetAddressesByAccountCmd(account *string) *GetAddressesByAccountCmd {
 	return &GetAddressesByAccountCmd{
 		Account: account,
 	}
@@ -215,8 +217,9 @@ func NewGetAddressInfoCmd(address string) *GetAddressInfoCmd {
 
 // GetBalanceCmd defines the getbalance JSON-RPC command.
 type GetBalanceCmd struct {
-	Account *string
-	MinConf *int `jsonrpcdefault:"1"`
+	Account     *string `jsonrpcdefault:"\"default\""`
+	MinConf     *int    `jsonrpcdefault:"1"`
+	AddressType *string `jsonrpcdefault:"\"*\""`
 }
 
 // NewGetBalanceCmd returns a new instance which can be used to issue a
@@ -242,8 +245,8 @@ func NewGetBalancesCmd() *GetBalancesCmd {
 
 // GetNewAddressCmd defines the getnewaddress JSON-RPC command.
 type GetNewAddressCmd struct {
-	Account     *string
-	AddressType *string // must be one of legacy / p2pkh or p2sh-p2wkh / p2sh-segwit, or p2wkh / bech32
+	Account     *string `jsonrpcdefault:"\"default\""`
+	AddressType *string `jsonrpcdefault:"\"legacy\""`
 }
 
 // NewGetNewAddressCmd returns a new instance which can be used to issue a
@@ -259,7 +262,8 @@ func NewGetNewAddressCmd(account *string) *GetNewAddressCmd {
 
 // GetRawChangeAddressCmd defines the getrawchangeaddress JSON-RPC command.
 type GetRawChangeAddressCmd struct {
-	Account *string
+	Account     *string `jsonrpcdefault:"\"default\""`
+	AddressType *string `jsonrpcdefault:"\"legacy\""`
 }
 
 // NewGetRawChangeAddressCmd returns a new instance which can be used to issue a
@@ -275,8 +279,8 @@ func NewGetRawChangeAddressCmd(account *string) *GetRawChangeAddressCmd {
 
 // GetReceivedByAccountCmd defines the getreceivedbyaccount JSON-RPC command.
 type GetReceivedByAccountCmd struct {
-	Account string
-	MinConf *int `jsonrpcdefault:"1"`
+	Account *string `jsonrpcdefault:"\"default\""`
+	MinConf *int    `jsonrpcdefault:"1"`
 }
 
 // NewGetReceivedByAccountCmd returns a new instance which can be used to issue
@@ -284,7 +288,7 @@ type GetReceivedByAccountCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetReceivedByAccountCmd(account string, minConf *int) *GetReceivedByAccountCmd {
+func NewGetReceivedByAccountCmd(account *string, minConf *int) *GetReceivedByAccountCmd {
 	return &GetReceivedByAccountCmd{
 		Account: account,
 		MinConf: minConf,
@@ -407,7 +411,8 @@ func NewKeyPoolRefillCmd(newSize *uint) *KeyPoolRefillCmd {
 
 // ListAccountsCmd defines the listaccounts JSON-RPC command.
 type ListAccountsCmd struct {
-	MinConf *int `jsonrpcdefault:"1"`
+	MinConf     *int    `jsonrpcdefault:"1"`
+	AddressType *string `jsonrpcdefault:"\"*\""`
 }
 
 // NewListAccountsCmd returns a new instance which can be used to issue a
@@ -501,10 +506,10 @@ func NewListSinceBlockCmd(blockHash *string, targetConfirms *int, includeWatchOn
 
 // ListTransactionsCmd defines the listtransactions JSON-RPC command.
 type ListTransactionsCmd struct {
-	Account          *string
-	Count            *int  `jsonrpcdefault:"10"`
-	From             *int  `jsonrpcdefault:"0"`
-	IncludeWatchOnly *bool `jsonrpcdefault:"false"`
+	Account          *string `jsonrpcdefault:"\"default\""`
+	Count            *int    `jsonrpcdefault:"10"`
+	From             *int    `jsonrpcdefault:"0"`
+	IncludeWatchOnly *bool   `jsonrpcdefault:"false"`
 }
 
 // NewListTransactionsCmd returns a new instance which can be used to issue a
@@ -562,6 +567,7 @@ type SendFromCmd struct {
 	ToAddress   string
 	Amount      float64 // In BTC
 	MinConf     *int    `jsonrpcdefault:"1"`
+	AddressType *string `jsonrpcdefault:"\"*\""`
 	Comment     *string
 	CommentTo   *string
 }
@@ -571,12 +577,15 @@ type SendFromCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSendFromCmd(fromAccount, toAddress string, amount float64, minConf *int, comment, commentTo *string) *SendFromCmd {
+func NewSendFromCmd(fromAccount, toAddress string, amount float64,
+	minConf *int, addrType *string, comment, commentTo *string) *SendFromCmd {
+
 	return &SendFromCmd{
 		FromAccount: fromAccount,
 		ToAddress:   toAddress,
 		Amount:      amount,
 		MinConf:     minConf,
+		AddressType: addrType,
 		Comment:     comment,
 		CommentTo:   commentTo,
 	}
@@ -587,6 +596,7 @@ type SendManyCmd struct {
 	FromAccount string
 	Amounts     map[string]float64 `jsonrpcusage:"{\"address\":amount,...}"` // In BTC
 	MinConf     *int               `jsonrpcdefault:"1"`
+	AddressType *string            `jsonrpcdefault:"\"*\""`
 	Comment     *string
 }
 
@@ -595,21 +605,24 @@ type SendManyCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSendManyCmd(fromAccount string, amounts map[string]float64, minConf *int, comment *string) *SendManyCmd {
+func NewSendManyCmd(fromAccount string, amounts map[string]float64,
+	minConf *int, addrType *string, comment *string) *SendManyCmd {
 	return &SendManyCmd{
 		FromAccount: fromAccount,
 		Amounts:     amounts,
 		MinConf:     minConf,
+		AddressType: addrType,
 		Comment:     comment,
 	}
 }
 
 // SendToAddressCmd defines the sendtoaddress JSON-RPC command.
 type SendToAddressCmd struct {
-	Address   string
-	Amount    float64
-	Comment   *string
-	CommentTo *string
+	Address     string
+	Amount      float64
+	AddressType *string `jsonrpcdefault:"\"*\""`
+	Comment     *string
+	CommentTo   *string
 }
 
 // NewSendToAddressCmd returns a new instance which can be used to issue a
@@ -617,12 +630,14 @@ type SendToAddressCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSendToAddressCmd(address string, amount float64, comment, commentTo *string) *SendToAddressCmd {
+func NewSendToAddressCmd(address string, amount float64, addrType *string,
+	comment, commentTo *string) *SendToAddressCmd {
 	return &SendToAddressCmd{
-		Address:   address,
-		Amount:    amount,
-		Comment:   comment,
-		CommentTo: commentTo,
+		Address:     address,
+		Amount:      amount,
+		AddressType: addrType,
+		Comment:     comment,
+		CommentTo:   commentTo,
 	}
 }
 

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -287,11 +287,12 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getaccountaddress", "acct")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetAccountAddressCmd("acct")
+				return btcjson.NewGetAccountAddressCmd(btcjson.String("acct"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getaccountaddress","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetAccountAddressCmd{
-				Account: "acct",
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{
@@ -300,11 +301,12 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getaddressesbyaccount", "acct")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetAddressesByAccountCmd("acct")
+				return btcjson.NewGetAddressesByAccountCmd(btcjson.String("acct"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getaddressesbyaccount","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetAddressesByAccountCmd{
-				Account: "acct",
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -330,8 +332,9 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetBalanceCmd{
-				Account: nil,
-				MinConf: btcjson.Int(1),
+				Account:     btcjson.String("default"),
+				MinConf:     btcjson.Int(1),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -344,8 +347,9 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetBalanceCmd{
-				Account: btcjson.String("acct"),
-				MinConf: btcjson.Int(1),
+				Account:     btcjson.String("acct"),
+				MinConf:     btcjson.Int(1),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -358,8 +362,9 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":["acct",6],"id":1}`,
 			unmarshalled: &btcjson.GetBalanceCmd{
-				Account: btcjson.String("acct"),
-				MinConf: btcjson.Int(6),
+				Account:     btcjson.String("acct"),
+				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -383,7 +388,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetNewAddressCmd{
-				Account: nil,
+				Account:     btcjson.String("default"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{
@@ -396,7 +402,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetNewAddressCmd{
-				Account: btcjson.String("acct"),
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{
@@ -409,7 +416,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetRawChangeAddressCmd{
-				Account: nil,
+				Account:     btcjson.String("default"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{
@@ -422,7 +430,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetRawChangeAddressCmd{
-				Account: btcjson.String("acct"),
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{
@@ -431,11 +440,11 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getreceivedbyaccount", "acct")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetReceivedByAccountCmd("acct", nil)
+				return btcjson.NewGetReceivedByAccountCmd(btcjson.String("acct"), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaccount","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetReceivedByAccountCmd{
-				Account: "acct",
+				Account: btcjson.String("acct"),
 				MinConf: btcjson.Int(1),
 			},
 		},
@@ -445,11 +454,11 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getreceivedbyaccount", "acct", 6)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetReceivedByAccountCmd("acct", btcjson.Int(6))
+				return btcjson.NewGetReceivedByAccountCmd(btcjson.String("acct"), btcjson.Int(6))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaccount","params":["acct",6],"id":1}`,
 			unmarshalled: &btcjson.GetReceivedByAccountCmd{
-				Account: "acct",
+				Account: btcjson.String("acct"),
 				MinConf: btcjson.Int(6),
 			},
 		},
@@ -601,7 +610,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"listaccounts","params":[],"id":1}`,
 			unmarshalled: &btcjson.ListAccountsCmd{
-				MinConf: btcjson.Int(1),
+				MinConf:     btcjson.Int(1),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -614,7 +624,8 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"listaccounts","params":[6],"id":1}`,
 			unmarshalled: &btcjson.ListAccountsCmd{
-				MinConf: btcjson.Int(6),
+				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("*"),
 			},
 		},
 		{
@@ -844,7 +855,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":[],"id":1}`,
 			unmarshalled: &btcjson.ListTransactionsCmd{
-				Account:          nil,
+				Account:          btcjson.String("default"),
 				Count:            btcjson.Int(10),
 				From:             btcjson.Int(0),
 				IncludeWatchOnly: btcjson.Bool(false),
@@ -1002,7 +1013,7 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendFromCmd("from", "1Address", 0.5, nil, nil, nil)
+				return btcjson.NewSendFromCmd("from", "1Address", 0.5, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5],"id":1}`,
 			unmarshalled: &btcjson.SendFromCmd{
@@ -1010,6 +1021,7 @@ func TestWalletSvrCmds(t *testing.T) {
 				ToAddress:   "1Address",
 				Amount:      0.5,
 				MinConf:     btcjson.Int(1),
+				AddressType: btcjson.String("*"),
 				Comment:     nil,
 				CommentTo:   nil,
 			},
@@ -1020,7 +1032,7 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6), nil, nil)
+				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6],"id":1}`,
 			unmarshalled: &btcjson.SendFromCmd{
@@ -1028,6 +1040,7 @@ func TestWalletSvrCmds(t *testing.T) {
 				ToAddress:   "1Address",
 				Amount:      0.5,
 				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("*"),
 				Comment:     nil,
 				CommentTo:   nil,
 			},
@@ -1035,37 +1048,59 @@ func TestWalletSvrCmds(t *testing.T) {
 		{
 			name: "sendfrom optional2",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "comment")
+				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "legacy")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6),
-					btcjson.String("comment"), nil)
+				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6), btcjson.String("legacy"),
+					nil, nil)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"comment"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"legacy"],"id":1}`,
 			unmarshalled: &btcjson.SendFromCmd{
 				FromAccount: "from",
 				ToAddress:   "1Address",
 				Amount:      0.5,
 				MinConf:     btcjson.Int(6),
-				Comment:     btcjson.String("comment"),
+				AddressType: btcjson.String("legacy"),
+				Comment:     nil,
 				CommentTo:   nil,
 			},
 		},
 		{
 			name: "sendfrom optional3",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "comment", "commentto")
+				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "legacy", "comment")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6),
-					btcjson.String("comment"), btcjson.String("commentto"))
+				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6), btcjson.String("legacy"),
+					btcjson.String("comment"), nil)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"comment","commentto"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"legacy","comment"],"id":1}`,
 			unmarshalled: &btcjson.SendFromCmd{
 				FromAccount: "from",
 				ToAddress:   "1Address",
 				Amount:      0.5,
 				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("legacy"),
+				Comment:     btcjson.String("comment"),
+				CommentTo:   nil,
+			},
+		},
+		{
+			name: "sendfrom optional4",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "legacy", "comment", "commentto")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewSendFromCmd("from", "1Address", 0.5, btcjson.Int(6), btcjson.String("legacy"),
+					btcjson.String("comment"), btcjson.String("commentto"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"legacy","comment","commentto"],"id":1}`,
+			unmarshalled: &btcjson.SendFromCmd{
+				FromAccount: "from",
+				ToAddress:   "1Address",
+				Amount:      0.5,
+				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("legacy"),
 				Comment:     btcjson.String("comment"),
 				CommentTo:   btcjson.String("commentto"),
 			},
@@ -1077,13 +1112,14 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				amounts := map[string]float64{"1Address": 0.5}
-				return btcjson.NewSendManyCmd("from", amounts, nil, nil)
+				return btcjson.NewSendManyCmd("from", amounts, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5}],"id":1}`,
 			unmarshalled: &btcjson.SendManyCmd{
 				FromAccount: "from",
 				Amounts:     map[string]float64{"1Address": 0.5},
 				MinConf:     btcjson.Int(1),
+				AddressType: btcjson.String("*"),
 				Comment:     nil,
 			},
 		},
@@ -1094,30 +1130,50 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				amounts := map[string]float64{"1Address": 0.5}
-				return btcjson.NewSendManyCmd("from", amounts, btcjson.Int(6), nil)
+				return btcjson.NewSendManyCmd("from", amounts, btcjson.Int(6), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6],"id":1}`,
 			unmarshalled: &btcjson.SendManyCmd{
 				FromAccount: "from",
 				Amounts:     map[string]float64{"1Address": 0.5},
 				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("*"),
 				Comment:     nil,
 			},
 		},
 		{
 			name: "sendmany optional2",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("sendmany", "from", `{"1Address":0.5}`, 6, "comment")
+				return btcjson.NewCmd("sendmany", "from", `{"1Address":0.5}`, 6, "legacy")
 			},
 			staticCmd: func() interface{} {
 				amounts := map[string]float64{"1Address": 0.5}
-				return btcjson.NewSendManyCmd("from", amounts, btcjson.Int(6), btcjson.String("comment"))
+				return btcjson.NewSendManyCmd("from", amounts, btcjson.Int(6), btcjson.String("legacy"), nil)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6,"comment"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6,"legacy"],"id":1}`,
 			unmarshalled: &btcjson.SendManyCmd{
 				FromAccount: "from",
 				Amounts:     map[string]float64{"1Address": 0.5},
 				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("legacy"),
+				Comment:     nil,
+			},
+		},
+		{
+			name: "sendmany optional3",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("sendmany", "from", `{"1Address":0.5}`, 6, "legacy", "comment")
+			},
+			staticCmd: func() interface{} {
+				amounts := map[string]float64{"1Address": 0.5}
+				return btcjson.NewSendManyCmd("from", amounts, btcjson.Int(6), btcjson.String("legacy"), btcjson.String("comment"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6,"legacy","comment"],"id":1}`,
+			unmarshalled: &btcjson.SendManyCmd{
+				FromAccount: "from",
+				Amounts:     map[string]float64{"1Address": 0.5},
+				MinConf:     btcjson.Int(6),
+				AddressType: btcjson.String("legacy"),
 				Comment:     btcjson.String("comment"),
 			},
 		},
@@ -1127,31 +1183,50 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendToAddressCmd("1Address", 0.5, nil, nil)
+				return btcjson.NewSendToAddressCmd("1Address", 0.5, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5],"id":1}`,
 			unmarshalled: &btcjson.SendToAddressCmd{
-				Address:   "1Address",
-				Amount:    0.5,
-				Comment:   nil,
-				CommentTo: nil,
+				Address:     "1Address",
+				Amount:      0.5,
+				AddressType: btcjson.String("*"),
+				Comment:     nil,
+				CommentTo:   nil,
 			},
 		},
 		{
 			name: "sendtoaddress optional1",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5, "comment", "commentto")
+				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5, "legacy")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendToAddressCmd("1Address", 0.5, btcjson.String("comment"),
+				return btcjson.NewSendToAddressCmd("1Address", 0.5, btcjson.String("legacy"), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"legacy"],"id":1}`,
+			unmarshalled: &btcjson.SendToAddressCmd{
+				Address:     "1Address",
+				Amount:      0.5,
+				AddressType: btcjson.String("legacy"),
+				Comment:     nil,
+				CommentTo:   nil,
+			},
+		},
+		{
+			name: "sendtoaddress optional2",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5, "legacy", "comment", "commentto")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewSendToAddressCmd("1Address", 0.5, btcjson.String("legacy"), btcjson.String("comment"),
 					btcjson.String("commentto"))
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"comment","commentto"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"legacy","comment","commentto"],"id":1}`,
 			unmarshalled: &btcjson.SendToAddressCmd{
-				Address:   "1Address",
-				Amount:    0.5,
-				Comment:   btcjson.String("comment"),
-				CommentTo: btcjson.String("commentto"),
+				Address:     "1Address",
+				Amount:      0.5,
+				AddressType: btcjson.String("legacy"),
+				Comment:     btcjson.String("comment"),
+				CommentTo:   btcjson.String("commentto"),
 			},
 		},
 		{

--- a/btcjson/walletsvrresults.go
+++ b/btcjson/walletsvrresults.go
@@ -174,6 +174,7 @@ type GetTransactionResult struct {
 	TimeReceived    int64                         `json:"timereceived"`
 	Details         []GetTransactionDetailsResult `json:"details"`
 	Hex             string                        `json:"hex"`
+	Generated       bool                          `json:"generated"`
 }
 
 type ScanningOrFalse struct {
@@ -288,7 +289,6 @@ type ListReceivedByAccountResult struct {
 // ListReceivedByAddressResult models the data from the listreceivedbyaddress
 // command.
 type ListReceivedByAddressResult struct {
-	Account           string   `json:"account"`
 	Address           string   `json:"address"`
 	Amount            float64  `json:"amount"`
 	Confirmations     uint64   `json:"confirmations"`

--- a/btcjson/walletsvrwscmds.go
+++ b/btcjson/walletsvrwscmds.go
@@ -40,7 +40,7 @@ func NewExportWatchingWalletCmd(account *string, download *bool) *ExportWatching
 
 // GetUnconfirmedBalanceCmd defines the getunconfirmedbalance JSON-RPC command.
 type GetUnconfirmedBalanceCmd struct {
-	Account *string
+	Account *string `jsonrpcdefault:"\"default\""`
 }
 
 // NewGetUnconfirmedBalanceCmd returns a new instance which can be used to issue
@@ -58,7 +58,7 @@ func NewGetUnconfirmedBalanceCmd(account *string) *GetUnconfirmedBalanceCmd {
 // command.
 type ListAddressTransactionsCmd struct {
 	Addresses []string
-	Account   *string
+	Account   *string `jsonrpcdefault:"\"default\""`
 }
 
 // NewListAddressTransactionsCmd returns a new instance which can be used to
@@ -75,7 +75,7 @@ func NewListAddressTransactionsCmd(addresses []string, account *string) *ListAdd
 
 // ListAllTransactionsCmd defines the listalltransactions JSON-RPC command.
 type ListAllTransactionsCmd struct {
-	Account *string
+	Account *string `jsonrpcdefault:"\"default\""`
 }
 
 // NewListAllTransactionsCmd returns a new instance which can be used to issue a

--- a/btcjson/walletsvrwscmds_test.go
+++ b/btcjson/walletsvrwscmds_test.go
@@ -71,7 +71,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 		{
 			name: "exportwatchingwallet optional2",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("exportwatchingwallet", "acct", true)
+				return btcjson.NewCmd("exportwatchingwallet", btcjson.String("acct"), true)
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewExportWatchingWalletCmd(btcjson.String("acct"),
@@ -93,7 +93,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getunconfirmedbalance","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetUnconfirmedBalanceCmd{
-				Account: nil,
+				Account: btcjson.String("default"),
 			},
 		},
 		{
@@ -120,7 +120,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"listaddresstransactions","params":[["1Address"]],"id":1}`,
 			unmarshalled: &btcjson.ListAddressTransactionsCmd{
 				Addresses: []string{"1Address"},
-				Account:   nil,
+				Account:   btcjson.String("default"),
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"listalltransactions","params":[],"id":1}`,
 			unmarshalled: &btcjson.ListAllTransactionsCmd{
-				Account: nil,
+				Account: btcjson.String("default"),
 			},
 		},
 		{

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -536,9 +536,10 @@ func (r FutureSendToAddressResult) Receive() (*chainhash.Hash, error) {
 // returned instance.
 //
 // See SendToAddress for the blocking version and more details.
-func (c *Client) SendToAddressAsync(address btcutil.Address, amount btcutil.Amount) FutureSendToAddressResult {
+func (c *Client) SendToAddressAsync(address btcutil.Address, amount btcutil.Amount,
+	addrType *string) FutureSendToAddressResult {
 	addr := address.EncodeAddress()
-	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), nil, nil)
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), addrType, nil, nil)
 	return c.SendCmd(cmd)
 }
 
@@ -550,8 +551,9 @@ func (c *Client) SendToAddressAsync(address btcutil.Address, amount btcutil.Amou
 //
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
-func (c *Client) SendToAddress(address btcutil.Address, amount btcutil.Amount) (*chainhash.Hash, error) {
-	return c.SendToAddressAsync(address, amount).Receive()
+func (c *Client) SendToAddress(address btcutil.Address, amount btcutil.Amount,
+	addrType *string) (*chainhash.Hash, error) {
+	return c.SendToAddressAsync(address, amount, addrType).Receive()
 }
 
 // SendToAddressCommentAsync returns an instance of a type that can be used to
@@ -560,12 +562,12 @@ func (c *Client) SendToAddress(address btcutil.Address, amount btcutil.Amount) (
 //
 // See SendToAddressComment for the blocking version and more details.
 func (c *Client) SendToAddressCommentAsync(address btcutil.Address,
-	amount btcutil.Amount, comment,
+	amount btcutil.Amount, addrType *string, comment string,
 	commentTo string) FutureSendToAddressResult {
 
 	addr := address.EncodeAddress()
-	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), &comment,
-		&commentTo)
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), addrType,
+		&comment, &commentTo)
 	return c.SendCmd(cmd)
 }
 
@@ -581,9 +583,10 @@ func (c *Client) SendToAddressCommentAsync(address btcutil.Address,
 //
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
-func (c *Client) SendToAddressComment(address btcutil.Address, amount btcutil.Amount, comment, commentTo string) (*chainhash.Hash, error) {
-	return c.SendToAddressCommentAsync(address, amount, comment,
-		commentTo).Receive()
+func (c *Client) SendToAddressComment(address btcutil.Address, amount btcutil.Amount,
+	addrType *string, comment, commentTo string) (*chainhash.Hash, error) {
+	return c.SendToAddressCommentAsync(address, amount, addrType,
+		comment, commentTo).Receive()
 }
 
 // FutureSendFromResult is a future promise to deliver the result of a
@@ -615,10 +618,11 @@ func (r FutureSendFromResult) Receive() (*chainhash.Hash, error) {
 // returned instance.
 //
 // See SendFrom for the blocking version and more details.
-func (c *Client) SendFromAsync(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount) FutureSendFromResult {
+func (c *Client) SendFromAsync(fromAccount string, toAddress btcutil.Address,
+	amount btcutil.Amount, addrType *string) FutureSendFromResult {
 	addr := toAddress.EncodeAddress()
 	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(), nil,
-		nil, nil)
+		addrType, nil, nil)
 	return c.SendCmd(cmd)
 }
 
@@ -630,8 +634,8 @@ func (c *Client) SendFromAsync(fromAccount string, toAddress btcutil.Address, am
 //
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
-func (c *Client) SendFrom(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount) (*chainhash.Hash, error) {
-	return c.SendFromAsync(fromAccount, toAddress, amount).Receive()
+func (c *Client) SendFrom(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount, addrType *string) (*chainhash.Hash, error) {
+	return c.SendFromAsync(fromAccount, toAddress, amount, addrType).Receive()
 }
 
 // SendFromMinConfAsync returns an instance of a type that can be used to get
@@ -639,10 +643,12 @@ func (c *Client) SendFrom(fromAccount string, toAddress btcutil.Address, amount 
 // the returned instance.
 //
 // See SendFromMinConf for the blocking version and more details.
-func (c *Client) SendFromMinConfAsync(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount, minConfirms int) FutureSendFromResult {
+func (c *Client) SendFromMinConfAsync(fromAccount string,
+	toAddress btcutil.Address, amount btcutil.Amount,
+	minConfirms int, addrType *string) FutureSendFromResult {
 	addr := toAddress.EncodeAddress()
 	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(),
-		&minConfirms, nil, nil)
+		&minConfirms, addrType, nil, nil)
 	return c.SendCmd(cmd)
 }
 
@@ -655,9 +661,10 @@ func (c *Client) SendFromMinConfAsync(fromAccount string, toAddress btcutil.Addr
 //
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
-func (c *Client) SendFromMinConf(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount, minConfirms int) (*chainhash.Hash, error) {
+func (c *Client) SendFromMinConf(fromAccount string, toAddress btcutil.Address,
+	amount btcutil.Amount, minConfirms int, addrType *string) (*chainhash.Hash, error) {
 	return c.SendFromMinConfAsync(fromAccount, toAddress, amount,
-		minConfirms).Receive()
+		minConfirms, addrType).Receive()
 }
 
 // SendFromCommentAsync returns an instance of a type that can be used to get
@@ -667,11 +674,11 @@ func (c *Client) SendFromMinConf(fromAccount string, toAddress btcutil.Address, 
 // See SendFromComment for the blocking version and more details.
 func (c *Client) SendFromCommentAsync(fromAccount string,
 	toAddress btcutil.Address, amount btcutil.Amount, minConfirms int,
-	comment, commentTo string) FutureSendFromResult {
+	addrType *string, comment, commentTo string) FutureSendFromResult {
 
 	addr := toAddress.EncodeAddress()
 	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(),
-		&minConfirms, &comment, &commentTo)
+		&minConfirms, addrType, &comment, &commentTo)
 	return c.SendCmd(cmd)
 }
 
@@ -687,11 +694,11 @@ func (c *Client) SendFromCommentAsync(fromAccount string,
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
 func (c *Client) SendFromComment(fromAccount string, toAddress btcutil.Address,
-	amount btcutil.Amount, minConfirms int,
+	amount btcutil.Amount, minConfirms int, addrType *string,
 	comment, commentTo string) (*chainhash.Hash, error) {
 
 	return c.SendFromCommentAsync(fromAccount, toAddress, amount,
-		minConfirms, comment, commentTo).Receive()
+		minConfirms, addrType, comment, commentTo).Receive()
 }
 
 // FutureSendManyResult is a future promise to deliver the result of a
@@ -728,7 +735,7 @@ func (c *Client) SendManyAsync(fromAccount string, amounts map[btcutil.Address]b
 	for addr, amount := range amounts {
 		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
-	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts, nil, nil)
+	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts, nil, nil, nil)
 	return c.SendCmd(cmd)
 }
 
@@ -751,14 +758,14 @@ func (c *Client) SendMany(fromAccount string, amounts map[btcutil.Address]btcuti
 // See SendManyMinConf for the blocking version and more details.
 func (c *Client) SendManyMinConfAsync(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount,
-	minConfirms int) FutureSendManyResult {
+	minConfirms int, addrType *string) FutureSendManyResult {
 
 	convertedAmounts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
 		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
 	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts,
-		&minConfirms, nil)
+		&minConfirms, nil, addrType)
 	return c.SendCmd(cmd)
 }
 
@@ -773,9 +780,10 @@ func (c *Client) SendManyMinConfAsync(fromAccount string,
 // WalletPassphrase function for more details.
 func (c *Client) SendManyMinConf(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount,
-	minConfirms int) (*chainhash.Hash, error) {
+	minConfirms int, addrType *string) (*chainhash.Hash, error) {
 
-	return c.SendManyMinConfAsync(fromAccount, amounts, minConfirms).Receive()
+	return c.SendManyMinConfAsync(fromAccount, amounts, minConfirms,
+		addrType).Receive()
 }
 
 // SendManyCommentAsync returns an instance of a type that can be used to get
@@ -785,14 +793,14 @@ func (c *Client) SendManyMinConf(fromAccount string,
 // See SendManyComment for the blocking version and more details.
 func (c *Client) SendManyCommentAsync(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount, minConfirms int,
-	comment string) FutureSendManyResult {
+	addrType *string, comment string) FutureSendManyResult {
 
 	convertedAmounts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
 		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
 	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts,
-		&minConfirms, &comment)
+		&minConfirms, &comment, addrType)
 	return c.SendCmd(cmd)
 }
 
@@ -808,10 +816,10 @@ func (c *Client) SendManyCommentAsync(fromAccount string,
 // WalletPassphrase function for more details.
 func (c *Client) SendManyComment(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount, minConfirms int,
-	comment string) (*chainhash.Hash, error) {
+	addrType *string, comment string) (*chainhash.Hash, error) {
 
 	return c.SendManyCommentAsync(fromAccount, amounts, minConfirms,
-		comment).Receive()
+		addrType, comment).Receive()
 }
 
 // *************************
@@ -1135,8 +1143,8 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 // function on the returned instance.
 //
 // See GetRawChangeAddress for the blocking version and more details.
-func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddressResult {
-	cmd := btcjson.NewGetRawChangeAddressCmd(&account)
+func (c *Client) GetRawChangeAddressAsync(account *string) FutureGetRawChangeAddressResult {
+	cmd := btcjson.NewGetRawChangeAddressCmd(account)
 	result := FutureGetRawChangeAddressResult{
 		network:         c.chainParams,
 		responseChannel: c.SendCmd(cmd),
@@ -1147,7 +1155,7 @@ func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddr
 // GetRawChangeAddress returns a new address for receiving change that will be
 // associated with the provided account.  Note that this is only for raw
 // transactions and NOT for normal use.
-func (c *Client) GetRawChangeAddress(account string) (btcutil.Address, error) {
+func (c *Client) GetRawChangeAddress(account *string) (btcutil.Address, error) {
 	return c.GetRawChangeAddressAsync(account).Receive()
 }
 
@@ -1226,7 +1234,7 @@ func (r FutureGetAccountAddressResult) Receive() (btcutil.Address, error) {
 // the returned instance.
 //
 // See GetAccountAddress for the blocking version and more details.
-func (c *Client) GetAccountAddressAsync(account string) FutureGetAccountAddressResult {
+func (c *Client) GetAccountAddressAsync(account *string) FutureGetAccountAddressResult {
 	cmd := btcjson.NewGetAccountAddressCmd(account)
 	result := FutureGetAccountAddressResult{
 		network:         c.chainParams,
@@ -1237,7 +1245,7 @@ func (c *Client) GetAccountAddressAsync(account string) FutureGetAccountAddressR
 
 // GetAccountAddress returns the current Bitcoin address for receiving payments
 // to the specified account.
-func (c *Client) GetAccountAddress(account string) (btcutil.Address, error) {
+func (c *Client) GetAccountAddress(account *string) (btcutil.Address, error) {
 	return c.GetAccountAddressAsync(account).Receive()
 }
 
@@ -1317,7 +1325,7 @@ func (r FutureGetAddressesByAccountResult) Receive() ([]btcutil.Address, error) 
 // function on the returned instance.
 //
 // See GetAddressesByAccount for the blocking version and more details.
-func (c *Client) GetAddressesByAccountAsync(account string) FutureGetAddressesByAccountResult {
+func (c *Client) GetAddressesByAccountAsync(account *string) FutureGetAddressesByAccountResult {
 	cmd := btcjson.NewGetAddressesByAccountCmd(account)
 	result := FutureGetAddressesByAccountResult{
 		network:         c.chainParams,
@@ -1328,7 +1336,7 @@ func (c *Client) GetAddressesByAccountAsync(account string) FutureGetAddressesBy
 
 // GetAddressesByAccount returns the list of addresses associated with the
 // passed account.
-func (c *Client) GetAddressesByAccount(account string) ([]btcutil.Address, error) {
+func (c *Client) GetAddressesByAccount(account *string) ([]btcutil.Address, error) {
 	return c.GetAddressesByAccountAsync(account).Receive()
 }
 
@@ -1709,7 +1717,7 @@ func (r FutureGetReceivedByAccountResult) Receive() (btcutil.Amount, error) {
 // function on the returned instance.
 //
 // See GetReceivedByAccount for the blocking version and more details.
-func (c *Client) GetReceivedByAccountAsync(account string) FutureGetReceivedByAccountResult {
+func (c *Client) GetReceivedByAccountAsync(account *string) FutureGetReceivedByAccountResult {
 	cmd := btcjson.NewGetReceivedByAccountCmd(account, nil)
 	return c.SendCmd(cmd)
 }
@@ -1719,7 +1727,7 @@ func (c *Client) GetReceivedByAccountAsync(account string) FutureGetReceivedByAc
 //
 // See GetReceivedByAccountMinConf to override the minimum number of
 // confirmations.
-func (c *Client) GetReceivedByAccount(account string) (btcutil.Amount, error) {
+func (c *Client) GetReceivedByAccount(account *string) (btcutil.Amount, error) {
 	return c.GetReceivedByAccountAsync(account).Receive()
 }
 
@@ -1728,8 +1736,8 @@ func (c *Client) GetReceivedByAccount(account string) (btcutil.Amount, error) {
 // function on the returned instance.
 //
 // See GetReceivedByAccountMinConf for the blocking version and more details.
-func (c *Client) GetReceivedByAccountMinConfAsync(account string, minConfirms int) FutureGetReceivedByAccountResult {
-	cmd := btcjson.NewGetReceivedByAccountCmd(account, &minConfirms)
+func (c *Client) GetReceivedByAccountMinConfAsync(account *string, minConfirms *int) FutureGetReceivedByAccountResult {
+	cmd := btcjson.NewGetReceivedByAccountCmd(account, minConfirms)
 	return c.SendCmd(cmd)
 }
 
@@ -1738,7 +1746,7 @@ func (c *Client) GetReceivedByAccountMinConfAsync(account string, minConfirms in
 // confirmations.
 //
 // See GetReceivedByAccount to use the default minimum number of confirmations.
-func (c *Client) GetReceivedByAccountMinConf(account string, minConfirms int) (btcutil.Amount, error) {
+func (c *Client) GetReceivedByAccountMinConf(account *string, minConfirms *int) (btcutil.Amount, error) {
 	return c.GetReceivedByAccountMinConfAsync(account, minConfirms).Receive()
 }
 


### PR DESCRIPTION
Most of the updates add optional arguments with default values.