### PR TITLE
error properly when lbcd fails to connect in HTTP POST mode

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -774,7 +774,8 @@ func (c *Client) handleSendPostMessage(jReq *jsonRequest) {
 	tries := 10
 	for i := 0; tries == 0 || i < tries; i++ {
 		bodyReader := bytes.NewReader(jReq.marshalledJSON)
-		httpReq, err := http.NewRequest("POST", url, bodyReader)
+		var httpReq *http.Request
+		httpReq, err = http.NewRequest("POST", url, bodyReader)
 		if err != nil {
 			jReq.responseChan <- &Response{result: nil, err: err}
 			return
@@ -786,7 +787,8 @@ func (c *Client) handleSendPostMessage(jReq *jsonRequest) {
 		}
 
 		// Configure basic access authorization.
-		user, pass, err := c.config.getAuth()
+		var user, pass string
+		user, pass, err = c.config.getAuth()
 		if err != nil {
 			jReq.responseChan <- &Response{result: nil, err: err}
 			return


### PR DESCRIPTION
in the case where you're e.g. trying to connect to an invalid address, the err vars in `handleSendPostMessage()` were being shadowed inside the for loop. if `c.httpClient.Do()` returned an error, that error never got returned upstream. then `ioutil.ReadAll(httpResponse.Body)` would get a nil pointer dereference. 

this fixes that case.