### PR TITLE
Relax witness size checking

### DIFF
--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -96,11 +96,13 @@ const (
 
 	// maxWitnessItemsPerInput is the maximum number of witness items to
 	// be read for the witness data for a single TxIn. This number is
-	// derived using a possble lower bound for the encoding of a witness
+	// derived using a possible lower bound for the encoding of a witness
 	// item: 1 byte for length + 1 byte for the witness item itself, or two
 	// bytes. This value is then divided by the currently allowed maximum
-	// "cost" for a transaction.
-	maxWitnessItemsPerInput = 500000
+	// "cost" for a transaction. We use this for an upper bound for the
+	// buffer and consensus makes sure that the weight of a transaction
+	// cannot be more than 4000000.
+	maxWitnessItemsPerInput = 4_000_000
 
 	// maxWitnessItemSize is the maximum allowed size for an item within
 	// an input's witness data. This value is bounded by the largest

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -103,10 +103,9 @@ const (
 	maxWitnessItemsPerInput = 500000
 
 	// maxWitnessItemSize is the maximum allowed size for an item within
-	// an input's witness data. This number is derived from the fact that
-	// for script validation, each pushed item onto the stack must be less
-	// than 10k bytes.
-	maxWitnessItemSize = 11000
+	// an input's witness data. This value is bounded by the largest
+	// possible block size, post segwit v1 (taproot).
+	maxWitnessItemSize = 4_000_000
 )
 
 // TxFlagMarker is the first byte of the FLAG field in a bitcoin tx
@@ -588,8 +587,9 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 			// item itself.
 			txin.Witness = make([][]byte, witCount)
 			for j := uint64(0); j < witCount; j++ {
-				txin.Witness[j], err = readScript(r, pver,
-					maxWitnessItemSize, "script witness item")
+				txin.Witness[j], err = readScript(
+					r, pver, maxWitnessItemSize, "script witness item",
+				)
 				if err != nil {
 					returnScriptBuffers()
 					return err


### PR DESCRIPTION
this is a response to @nikooo777's inqury about  [CVE-2022-44797](https://devhub.checkmarx.com/cve-details/CVE-2022-44797/?utm_source=jetbrains&utm_medium=referral&utm_campaign=goland&utm_term=go)
 and [CVE-2022-39389](https://devhub.checkmarx.com/cve-details/CVE-2022-39389/?utm_source=jetbrains&utm_medium=referral&utm_campaign=goland&utm_term=go)

At the moment, I don't have enough bandwidth to further investigate if lbcd is impacted, but it seems fine as we only have two implementations (lbcd and lbrycrd), and both have the same witness-size-checking.